### PR TITLE
fixed the letterbox creation and user redirection issues

### DIFF
--- a/app/letterhome/page.js
+++ b/app/letterhome/page.js
@@ -41,6 +41,7 @@ export default function Home() {
         router.push("/login");
       } else {
         const letterboxes = await fetchLetterboxes();
+        
         const letterboxIds = letterboxes.map((l) => l.id);
         let letters = [];
         for (const id of letterboxIds) {
@@ -79,7 +80,8 @@ export default function Home() {
           const userData = docSnap.data();
           setUserName(userData.first_name || "Unknown User");
           setCountry(userData.country || "Unknown Country");
-		  setProfileImage(userData?.photo_uri || "");
+		      setProfileImage(userData?.photo_uri || "");
+          
         } else {
           console.log("No such document!");
         }


### PR DESCRIPTION
When the user clicks the "Send a Message" button on the discovery page, the following actions will take place based on whether the user is new or has an existing letterbox document:

1. **For New Users:** If the user does not have a letterbox document, create one for them.

2. **For Existing Users:** If the letterbox document already exists, add the kid's ID to the members array within that document.

After either action, create a draft letter and redirect the user to the letter homepage, where the kid will be displayed in the list.