### PR TITLE
Merge Profile page view only to UI Standard

### DIFF
--- a/app/letterhome/page.js
+++ b/app/letterhome/page.js
@@ -37,6 +37,7 @@ export default function Home() {
   const [error, setError] = useState("");
   const [profileImage, setProfileImage] = useState("");
   const [showWelcome, setShowWelcome] = useState(false);
+  const [userId, setUserId] = useState("");
   const router = useRouter();
 
   useEffect(() => {
@@ -77,6 +78,7 @@ export default function Home() {
     const fetchUserData = async () => {
       if (auth.currentUser) {
         const uid = auth.currentUser.uid;
+        setUserId(uid)
         const docRef = doc(db, "users", uid);
         const docSnap = await getDoc(docRef);
 
@@ -120,6 +122,7 @@ export default function Home() {
           userName={userName}
           country={country}
           profileImage={profileImage}
+          id={userId}
         />
 
         <main className="p-6">

--- a/app/profile-view/[id]/page.js
+++ b/app/profile-view/[id]/page.js
@@ -3,13 +3,10 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
-import Link from "next/link";
 import { getAuth, onAuthStateChanged, signOut } from "firebase/auth";
 import { doc, getDoc, setDoc } from "firebase/firestore";
 import { db, auth } from "../../firebaseConfig";
 
-import { updateDoc } from "firebase/firestore";
-import * as Sentry from "@sentry/nextjs";
 import {
   User,
   MapPin,
@@ -24,11 +21,8 @@ import {
   Palette,
 } from "lucide-react";
 import Button from "../../../components/general/Button";
-import Input from "../../../components/general/Input";
-import Modal from "../../../components/general/Modal";
 import { BackButton } from "../../../components/general/BackButton";
 import { PageContainer } from "../../../components/general/PageContainer";
-import Popover from "../../../components/general/Popover";
 
 export default function Page({ params }) {
   const { id } = params;
@@ -43,19 +37,11 @@ export default function Page({ params }) {
   const [isOrphan, setIsOrphan] = useState(false);
   const [guardian, setGuardian] = useState("");
   const [dreamJob, setDreamJob] = useState("");
-  const [gender, setGender] = useState("");
+  //const [gender, setGender] = useState("");
   const [hobby, setHobby] = useState("");
   const [favoriteColor, setFavoriteColor] = useState("");
   const [photoUri, setPhotoUri] = useState("");
   const [user, setUser] = useState(null);
-  const [isSaving, setIsSaving] = useState(false);
-  
-  // Modal state
-  const [isEducationModalOpen, setIsEducationModalOpen] = useState(false);
-  const [isGuardianModalOpen, setIsGuardianModalOpen] = useState(false);
-  const [isOrphanModalOpen, setIsOrphanModalOpen] = useState(false);
-  const [isBioModalOpen, setIsBioModalOpen] = useState(false);
-  const [tempBio, setTempBio] = useState("");
 
   const router = useRouter();
 
@@ -91,39 +77,6 @@ export default function Page({ params }) {
     fetchUserData();
   }, [auth.currentUser]);
 
-  // Save profile data to Firestore
-  const saveProfileData = async () => {
-    if (auth.currentUser) {
-      const uid = auth.currentUser.uid;
-      const userProfileRef = doc(db, "users", uid);
-
-      const userProfile = {
-        first_name: firstName,
-        last_name: lastName,
-        email,
-        birthday,
-        country,
-        village,
-        bio,
-        education_level: educationLevel,
-        is_orphan: isOrphan.toLowerCase() === "yes" ? true : false,
-        gaurdian: guardian,
-        dream_job: dreamJob,
-        hobby,
-        favorite_color: favoriteColor,
-        gender,
-      };
-
-      try {
-        await updateDoc(userProfileRef, userProfile);
-        alert("Profile saved successfully!");
-      } catch (error) {
-        alert("Error saving profile");
-        Sentry.captureException("Error saving profile " + error);
-      }
-    }
-  };
-
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
       if (currentUser) {
@@ -148,352 +101,219 @@ export default function Page({ params }) {
     }
   };
 
-  // Education options
-  const educationOptions = [
-    "Elementary",
-    "Middle",
-    "High School",
-    "College/University",
-    "No Grade"
-  ];
-
-  // Guardian options
-  const guardianOptions = [
-    "Parents",
-    "Adoptive Parents",
-    "Aunt/Uncle",
-    "Grandparents",
-    "Other Family",
-    "Friends",
-    "Other"
-  ];
-
-  // Education Modal content
-  const educationModalContent = (
-    <div className="space-y-4">
-      <p className="text-sm text-gray-500 mb-4">Select your education level:</p>
-      <div className="grid grid-cols-1 gap-3">
-        {educationOptions.map((option) => (
-          <button
-            key={option}
-            className={`p-3 rounded-lg text-left ${
-              educationLevel === option
-                ? "bg-green-100 border border-green-500"
-                : "bg-gray-50 hover:bg-gray-100"
-            }`}
-            onClick={() => {
-              setEducationLevel(option);
-              setIsEducationModalOpen(false);
-            }}
-          >
-            {option}
-          </button>
-        ))}
-      </div>
-    </div>
-  );
-
-  // Guardian Modal content
-  const guardianModalContent = (
-    <div className="space-y-4">
-      <p className="text-sm text-gray-500 mb-4">Select your guardian:</p>
-      <div className="grid grid-cols-1 gap-3">
-        {guardianOptions.map((option) => (
-          <button
-            key={option}
-            className={`p-3 rounded-lg text-left ${
-              guardian === option
-                ? "bg-green-100 border border-green-500"
-                : "bg-gray-50 hover:bg-gray-100"
-            }`}
-            onClick={() => {
-              setGuardian(option);
-              setIsGuardianModalOpen(false);
-            }}
-          >
-            {option}
-          </button>
-        ))}
-      </div>
-    </div>
-  );
-
-  // Orphan Modal content
-  const orphanModalContent = (
-    <div className="space-y-4">
-      <p className="text-sm text-gray-500 mb-4">Are you an orphan?</p>
-      <div className="grid grid-cols-2 gap-3">
-        {["Yes", "No"].map((option) => (
-          <button
-            key={option}
-            className={`p-3 rounded-lg text-center ${
-              isOrphan === option
-                ? "bg-green-100 border border-green-500"
-                : "bg-gray-50 hover:bg-gray-100"
-            }`}
-            onClick={() => {
-              setIsOrphan(option);
-              setIsOrphanModalOpen(false);
-            }}
-          >
-            {option}
-          </button>
-        ))}
-      </div>
-    </div>
-  );
-
-  // Bio Modal content
-  const bioModalContent = (
-    <div className="space-y-4">
-      <p className="text-sm text-gray-500 mb-2">Share your challenges or a brief bio:</p>
-      <textarea
-        value={tempBio}
-        onChange={(e) => setTempBio(e.target.value)}
-        className="w-full h-32 p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-transparent resize-none"
-        placeholder="Write about yourself or challenges you've faced..."
-        maxLength={200}
-      />
-      <div className="flex justify-between items-center">
-        <span className="text-xs text-gray-500">
-          {tempBio.length}/200 characters
-        </span>
-        <Button
-          btnText="Save"
-          color="bg-green-800"
-          hoverColor="hover:bg-[#48801c]"
-          textColor="text-white"
-          rounded="rounded-lg"
-          size="w-24"
-          onClick={() => {
-            setBio(tempBio);
-            setIsBioModalOpen(false);
-          }}
-        />
-      </div>
-    </div>
-  );
-
-  // Open bio Modal and set temp bio
-  const handleOpenBioModal = () => {
-    setTempBio(bio);
-    setIsBioModalOpen(true);
-  };
-
   return (
     <div className="bg-gray-50 min-h-screen">
       <PageContainer maxWidth="lg" padding="p-6 pt-20">
-      <BackButton />
-      <div className="max-w-lg mx-auto p-6 pt-4">
-        <div className="flex justify-end">
-          <Button
-            onClick={handleLogout}
-            color="bg-red-500"
-            textColor="text-white"
-            hoverColor="hover:bg-red-600"
-            btnType="submit"
-            rounded="rounded-lg"
-            btnText="Log out"
-            size="w-24"
-          />
-        </div>
-
-        {/* Education Level Modal */}
-        <Modal
-          isOpen={isEducationModalOpen}
-          onClose={() => setIsEducationModalOpen(false)}
-          title="Education Level"
-          content={educationModalContent}
-          width="large"
-        />
-
-        {/* Guardian Modal */}
-        <Modal
-          isOpen={isGuardianModalOpen}
-          onClose={() => setIsGuardianModalOpen(false)}
-          title="Guardian"
-          content={guardianModalContent}
-          width="large"
-        />
-
-        {/* Orphan Modal */}
-        <Modal
-          isOpen={isOrphanModalOpen}
-          onClose={() => setIsOrphanModalOpen(false)}
-          title="Orphan Status"
-          content={orphanModalContent}         
-          width="large"
-        />
-
-        {/* Bio Modal */}
-        <Modal
-          isOpen={isBioModalOpen}
-          onClose={() => setIsBioModalOpen(false)}
-          title="Bio/Challenges"
-          content={bioModalContent}
-          width="large"
-          
-        />
-
-        {/* Profile Image */}
-        <div className="my-6">
-          <div className="relative w-24 h-24 mx-auto">
-            <Image
-              src={photoUri ? photoUri : "/murphylogo.png"}
-              layout="fill"
-              className="rounded-full"
-              alt="Profile picture"
+        <BackButton />
+        <div className="max-w-lg mx-auto p-6 pt-4">
+          <div className="flex justify-end">
+            <Button
+              onClick={handleLogout}
+              color="bg-red-500"
+              textColor="text-white"
+              hoverColor="hover:bg-red-600"
+              btnType="submit"
+              rounded="rounded-lg"
+              btnText="Log out"
+              size="w-24"
             />
-            {/* Edit Icon */}
-            
           </div>
-        </div>
 
-        {/* Form Fields */}
-        <div className="space-y-6 mb-[120px]">
-          {/* Personal Information Section */}
-          <div className="space-y-4">
-            <h3 className="text-blue-900 font-medium text-lg mb-4">
-              Personal Information
-            </h3>
-
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-gray-100 rounded-lg">
-                <User className="w-5 h-5 text-gray-600" />
-              </div>
-              <div className="flex-1">
-                <p className="text-sm text-500">First Name</p>
-                  <span>{firstName != "" ? firstName : "Unknown"}</span>
-              </div>
+          {/* Profile Image */}
+          <div className="my-6">
+            <div className="relative w-24 h-24 mx-auto">
+              <Image
+                src={photoUri ? photoUri : "/murphylogo.png"}
+                layout="fill"
+                className="rounded-full"
+                alt="Profile picture"
+              />
+              {/* Edit Icon */}
+              {auth.currentUser.uid === id && (
+                <div
+                  className="absolute bottom-0 right-0 bg-blue-600 text-white p-2 rounded-full curspr-pointer"
+                  onClick={() => {
+                    router.push("/profile");
+                  }}
+                >
+                  <svg
+                    className="h-6 w-6"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <defs>
+                      <marker
+                        id="arrow"
+                        viewBox="0 0 10 10"
+                        refX="5"
+                        refY="5"
+                        markerWidth="1"
+                        markerHeight="1"
+                        orient="auto-start-reverse"
+                      >
+                        <path d="M 0 0 L 10 5 L 0 10 z" fill="white" />
+                      </marker>
+                    </defs>
+                    <path
+                      strokeWidth="4"
+                      d="M18 6 L5 19"
+                      markerEnd="url(#arrow)"
+                    />
+                    <path strokeWidth="4" d="M22 2 L19 5" />
+                  </svg>
+                </div>
+              )}
             </div>
+          </div>
 
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-gray-100 rounded-lg">
-                <User className="w-5 h-5 text-gray-600" />
-              </div>
-              <div className="flex-1">
-                <p className="text-sm text-500">Last Name</p>
-                  <span>{lastName != "" ? lastName : "Unknown"}</span>
-              </div>
+          {/* Name, Country & Bio */}
+          <div className="space-y-1 mb-6">
+            <div className="text-center text-2xl">
+              <span>
+                {firstName != "" ? firstName : ""}{" "}
+                {lastName != "" ? lastName : ""}
+              </span>
             </div>
-
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-gray-100 rounded-lg">
-                <MapPin className="w-5 h-5 text-gray-600" />
-              </div>
-              <div className="flex-1">
-                <p className="text-sm text-500">Country</p>
-                  <span>{country != "" ? country : "Unknown"}</span>
-              </div>
+            <div className="text-center">
+              <span>{country != "" ? country : ""}</span>
             </div>
-
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-gray-100 rounded-lg">
-                <Home className="w-5 h-5 text-gray-600" />
-              </div>
-              <div className="flex-1">
-                <p className="text-sm text-500">Village</p>
-                  <span>{village != "" ? village : "Unknown"}</span>
-              </div>
+            <div className="text-center">
+              <span>
+                {bio ? "\u0022" : ""}
+                {bio ? bio : ""}
+                {bio ? "\u0022" : ""}
+              </span>
             </div>
+          </div>
 
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-gray-100 rounded-lg">
-                <FileText className="w-5 h-5 text-gray-600" />
-              </div>
-              <div className="flex-1">
-                <p className="text-sm text-500">Bio/Challenges faced</p>
-                  <span className="truncate">
-                    {bio ? bio : "Unknown"}
+          {/* Info */}
+          <div className="space-y-8 mb-[120px]">
+            {/* Personal Information Section */}
+            <div className="space-y-4">
+              <div className="h-4"></div>
+              <h3 className="text-blue-900 font-medium text-sm mb-5">
+                Personal Information
+              </h3>
+              <div className="h-4"></div>
+
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-gray-100 rounded-lg">
+                  <Home className="w-5 h-5 text-600" />
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm text-gray-500">Village</p>
+                  <span className={village != "" ? "" : "text-gray-500"}>
+                    {village != "" ? village : "Unknown"}
                   </span>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-gray-100 rounded-lg">
+                  <Calendar className="w-5 h-5 text-600" />
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm text-gray-500">Birthday</p>
+                  <span className={birthday != "" ? "" : "text-gray-500"}>
+                    {birthday || "Unknown"}
+                  </span>
+                </div>
               </div>
             </div>
 
+            {/* Education & Family Section */}
+            <div className="space-y-4">
+              <div className="h-4"></div>
+              <h3 className="text-blue-900 font-medium text-sm mb-4">
+                Education & Family
+              </h3>
+              <div className="h-4"></div>
+
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-gray-100 rounded-lg">
+                  <GraduationCap className="w-5 h-5 text-600" />
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm text-gray-500">Education level</p>
+                  <span className={educationLevel != "" ? "" : "text-gray-500"}>
+                    {educationLevel || "Unknown"}
+                  </span>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-gray-100 rounded-lg">
+                  <Users className="w-5 h-5 text-600" />
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm text-gray-500">Guardian</p>
+                  <span className={guardian != "" ? "" : "text-gray-500"}>
+                    {guardian || "Unknown"}
+                  </span>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-gray-100 rounded-lg">
+                  <Heart className="w-5 h-5 text-600" />
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm text-gray-500">Is orphan</p>
+                  <span className={isOrphan != "" ? "" : "text-gray-500"}>
+                    {isOrphan || "Unknown"}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* Interest Section */}
+            <div className="space-y-4">
+              <div className="h-4"></div>
+              <h3 className="text-blue-900 font-medium text-sm mb-4">
+                Interest
+              </h3>
+              <div className="h-4"></div>
+
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-gray-100 rounded-lg">
+                  <Briefcase className="w-5 h-5 text-600" />
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm text-gray-500">Dream Job</p>
+                  <span className={dreamJob != "" ? "" : "text-gray-500"}>
+                    {dreamJob != "" ? dreamJob : "Unknown"}
+                  </span>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-3">
+                <div className="p-2 bg-gray-100 rounded-lg">
+                  <Square className="w-5 h-5 text-600" />
+                </div>
+                <div className="flex-1">
+                  <p className="text-sm text-gray-500">Hobby</p>
+                  <span className={hobby != "" ? "" : "text-gray-500"}>
+                    {hobby != "" ? hobby : "Unknown"}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* Favorite Color */}
             <div className="flex items-center gap-3">
               <div className="p-2 bg-gray-100 rounded-lg">
-                <Calendar className="w-5 h-5 text-gray-600" />
+                <Palette className="w-5 h-5 text-600" />
               </div>
               <div className="flex-1">
-                <p className="text-sm text-500">Birthday</p>
-                  <span>{birthday || "Unknown"}</span>
+                <p className="text-sm text-gray-500">Favorite Color</p>
+                <span className={favoriteColor != "" ? "" : "text-gray-500"}>
+                  {favoriteColor != "" ? favoriteColor : "Unknown"}
+                </span>
               </div>
             </div>
-          </div>
-
-          {/* Education & Family Section */}
-          <div className="space-y-4">
-            <h3 className="text-blue-900 font-medium text-lg mb-4">
-              Education & Family
-            </h3>
-
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-gray-100 rounded-lg">
-                <GraduationCap className="w-5 h-5 text-gray-600" />
-              </div>
-              <div className="flex-1">
-                <p className="text-sm text-500">Education level</p>
-                  <span>{educationLevel || "Unknown"}</span>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-gray-100 rounded-lg">
-                <Users className="w-5 h-5 text-gray-600" />
-              </div>
-              <div className="flex-1">
-                <p className="text-sm text-500">Guardian</p>
-                  <span>{guardian || "Unknown"}</span>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-gray-100 rounded-lg">
-                <Heart className="w-5 h-5 text-gray-600" />
-              </div>
-              <div className="flex-1">
-                <p className="text-sm text-500">Is orphan</p>
-                  <span>{isOrphan || "Unknown"}</span>
-              </div>
-            </div>
-          </div>
-
-          {/* Interest Section */}
-          <div className="space-y-4">
-            <h3 className="text-blue-900 font-medium text-lg mb-4">Interest</h3>
-
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-gray-100 rounded-lg">
-                <Briefcase className="w-5 h-5 text-gray-600" />
-              </div>
-              <div className="flex-1">
-                <p className="text-sm text-500">Dream Job</p>
-                  <span>{dreamJob != "" ? dreamJob : "Unknown"}</span>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-gray-100 rounded-lg">
-                <Square className="w-5 h-5 text-gray-600" />
-              </div>
-              <div className="flex-1">
-                <p className="text-sm text-500">Hobby</p>
-                  <span>{hobby != "" ? hobby : "Unknown"}</span>
-              </div>
-            </div>
-          </div>
-
-          {/* Favorite Color */}
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-gray-100 rounded-lg">
-              <Palette className="w-5 h-5 text-gray-600" />
-            </div>
-              <div className="flex-1">
-                <p className="text-sm text-500">Favorite Color</p>
-                  <span>{favoriteColor != "" ? favoriteColor : "Unknown"}</span>
-              </div>
           </div>
         </div>
-      </div>
       </PageContainer>
     </div>
   );

--- a/app/profile-view/[id]/page.js
+++ b/app/profile-view/[id]/page.js
@@ -23,6 +23,8 @@ import {
 import Button from "../../../components/general/Button";
 import { BackButton } from "../../../components/general/BackButton";
 import { PageContainer } from "../../../components/general/PageContainer";
+import ProfileSection from "../../../components/general/profile/ProfileSection";
+import InfoDisplay from "../../../components/general/profile/InfoDisplay";
 
 export default function Page({ params }) {
   const { id } = params;
@@ -129,7 +131,7 @@ export default function Page({ params }) {
                 alt="Profile picture"
               />
               {/* Edit Icon */}
-              {auth.currentUser.uid === id && (
+              {auth.currentUser?.uid === id && (
                 <div
                   className="absolute bottom-0 right-0 bg-blue-600 text-white p-2 rounded-full curspr-pointer"
                   onClick={() => {
@@ -190,128 +192,46 @@ export default function Page({ params }) {
           {/* Info */}
           <div className="space-y-8 mb-[120px]">
             {/* Personal Information Section */}
-            <div className="space-y-4">
-              <div className="h-4"></div>
-              <h3 className="text-blue-900 font-medium text-sm mb-5">
-                Personal Information
-              </h3>
-              <div className="h-4"></div>
+            <ProfileSection title="Personal Information">
+              <InfoDisplay title="Village" info={village}>
+                <Home className="w-5 h-5 text-600" />
+              </InfoDisplay>
 
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-gray-100 rounded-lg">
-                  <Home className="w-5 h-5 text-600" />
-                </div>
-                <div className="flex-1">
-                  <p className="text-sm text-gray-500">Village</p>
-                  <span className={village != "" ? "" : "text-gray-500"}>
-                    {village != "" ? village : "Unknown"}
-                  </span>
-                </div>
-              </div>
-
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-gray-100 rounded-lg">
-                  <Calendar className="w-5 h-5 text-600" />
-                </div>
-                <div className="flex-1">
-                  <p className="text-sm text-gray-500">Birthday</p>
-                  <span className={birthday != "" ? "" : "text-gray-500"}>
-                    {birthday || "Unknown"}
-                  </span>
-                </div>
-              </div>
-            </div>
+              <InfoDisplay title="Birthday" info={birthday}>
+                <Calendar className="w-5 h-5 text-600" />
+              </InfoDisplay>
+            </ProfileSection>
 
             {/* Education & Family Section */}
-            <div className="space-y-4">
-              <div className="h-4"></div>
-              <h3 className="text-blue-900 font-medium text-sm mb-4">
-                Education & Family
-              </h3>
-              <div className="h-4"></div>
+            <ProfileSection title="Education & Family">
+              <InfoDisplay title="Education level" info={educationLevel}>
+                <GraduationCap className="w-5 h-5 text-600" />
+              </InfoDisplay>
 
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-gray-100 rounded-lg">
-                  <GraduationCap className="w-5 h-5 text-600" />
-                </div>
-                <div className="flex-1">
-                  <p className="text-sm text-gray-500">Education level</p>
-                  <span className={educationLevel != "" ? "" : "text-gray-500"}>
-                    {educationLevel || "Unknown"}
-                  </span>
-                </div>
-              </div>
+              <InfoDisplay title="Guardian" info={guardian}>
+                <Users className="w-5 h-5 text-600" />
+              </InfoDisplay>
 
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-gray-100 rounded-lg">
-                  <Users className="w-5 h-5 text-600" />
-                </div>
-                <div className="flex-1">
-                  <p className="text-sm text-gray-500">Guardian</p>
-                  <span className={guardian != "" ? "" : "text-gray-500"}>
-                    {guardian || "Unknown"}
-                  </span>
-                </div>
-              </div>
-
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-gray-100 rounded-lg">
-                  <Heart className="w-5 h-5 text-600" />
-                </div>
-                <div className="flex-1">
-                  <p className="text-sm text-gray-500">Is orphan</p>
-                  <span className={isOrphan != "" ? "" : "text-gray-500"}>
-                    {isOrphan || "Unknown"}
-                  </span>
-                </div>
-              </div>
-            </div>
+              <InfoDisplay title="Is orphan" info={isOrphan}>
+                <Heart className="w-5 h-5 text-600" />
+              </InfoDisplay>
+            </ProfileSection>
 
             {/* Interest Section */}
-            <div className="space-y-4">
-              <div className="h-4"></div>
-              <h3 className="text-blue-900 font-medium text-sm mb-4">
-                Interest
-              </h3>
-              <div className="h-4"></div>
+            <ProfileSection title="Interest">
+              <InfoDisplay title="Dream Job" info={dreamJob}>
+                <Briefcase className="w-5 h-5 text-600" />
+              </InfoDisplay>
 
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-gray-100 rounded-lg">
-                  <Briefcase className="w-5 h-5 text-600" />
-                </div>
-                <div className="flex-1">
-                  <p className="text-sm text-gray-500">Dream Job</p>
-                  <span className={dreamJob != "" ? "" : "text-gray-500"}>
-                    {dreamJob != "" ? dreamJob : "Unknown"}
-                  </span>
-                </div>
-              </div>
+              <InfoDisplay title="Hobby" info={hobby}>
+                <Square className="w-5 h-5 text-600" />
+              </InfoDisplay>
 
-              <div className="flex items-center gap-3">
-                <div className="p-2 bg-gray-100 rounded-lg">
-                  <Square className="w-5 h-5 text-600" />
-                </div>
-                <div className="flex-1">
-                  <p className="text-sm text-gray-500">Hobby</p>
-                  <span className={hobby != "" ? "" : "text-gray-500"}>
-                    {hobby != "" ? hobby : "Unknown"}
-                  </span>
-                </div>
-              </div>
-            </div>
-
-            {/* Favorite Color */}
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-gray-100 rounded-lg">
+              {/* Favorite Color */}
+              <InfoDisplay title="Favorite Color" info={favoriteColor}>
                 <Palette className="w-5 h-5 text-600" />
-              </div>
-              <div className="flex-1">
-                <p className="text-sm text-gray-500">Favorite Color</p>
-                <span className={favoriteColor != "" ? "" : "text-gray-500"}>
-                  {favoriteColor != "" ? favoriteColor : "Unknown"}
-                </span>
-              </div>
-            </div>
+              </InfoDisplay>
+            </ProfileSection>
           </div>
         </div>
       </PageContainer>

--- a/app/profile-view/[id]/page.js
+++ b/app/profile-view/[id]/page.js
@@ -6,7 +6,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { getAuth, onAuthStateChanged, signOut } from "firebase/auth";
 import { doc, getDoc, setDoc } from "firebase/firestore";
-import { db, auth } from "../firebaseConfig";
+import { db, auth } from "../../firebaseConfig";
 
 import { updateDoc } from "firebase/firestore";
 import * as Sentry from "@sentry/nextjs";
@@ -23,15 +23,15 @@ import {
   Square,
   Palette,
 } from "lucide-react";
-import Button from "../../components/general/Button";
-import Input from "../../components/general/Input";
-import Modal from "../../components/general/Modal";
-import { BackButton } from "../../components/general/BackButton";
-import { PageContainer } from "../../components/general/PageContainer";
-import Popover from "../../components/general/Popover";
+import Button from "../../../components/general/Button";
+import Input from "../../../components/general/Input";
+import Modal from "../../../components/general/Modal";
+import { BackButton } from "../../../components/general/BackButton";
+import { PageContainer } from "../../../components/general/PageContainer";
+import Popover from "../../../components/general/Popover";
 
-export default function EditProfile() {
-  // State initializations
+export default function Page({ params }) {
+  const { id } = params;
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [email, setEmail] = useState("");
@@ -62,7 +62,7 @@ export default function EditProfile() {
   useEffect(() => {
     const fetchUserData = async () => {
       if (auth.currentUser) {
-        const uid = auth.currentUser.uid;
+        const uid = id;
         const docRef = doc(db, "users", uid);
         const docSnap = await getDoc(docRef);
         console.log(docSnap.data());
@@ -345,26 +345,7 @@ export default function EditProfile() {
               alt="Profile picture"
             />
             {/* Edit Icon */}
-            <div
-              className="absolute bottom-0 right-0 bg-blue-600 text-white p-2 rounded-full curspr-pointer"
-              onClick={() => {
-                router.push("/edit-profile-user-image");
-              }}
-            >
-              <svg
-                className="h-6 w-6"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M12 4v16m8-8H4"
-                />
-              </svg>
-            </div>
+            
           </div>
         </div>
 
@@ -381,17 +362,8 @@ export default function EditProfile() {
                 <User className="w-5 h-5 text-gray-600" />
               </div>
               <div className="flex-1">
-                <Input
-                  type="text"
-                  id="firstName"
-                  name="firstName"
-                  value={firstName}
-                  onChange={(e) => setFirstName(e.target.value)}
-                  label="First name"
-                  borderColor="border-gray-300"
-                  focusBorderColor="focus:border-green-800"
-                  bgColor="bg-transparent"
-                />
+                <p className="text-sm text-500">First Name</p>
+                  <span>{firstName != "" ? firstName : "Unknown"}</span>
               </div>
             </div>
 
@@ -400,17 +372,8 @@ export default function EditProfile() {
                 <User className="w-5 h-5 text-gray-600" />
               </div>
               <div className="flex-1">
-                <Input
-                  type="text"
-                  id="lastName"
-                  name="lastName"
-                  value={lastName}
-                  onChange={(e) => setLastName(e.target.value)}
-                  label="Last name"
-                  borderColor="border-gray-300"
-                  focusBorderColor="focus:border-green-800"
-                  bgColor="bg-transparent"
-                />
+                <p className="text-sm text-500">Last Name</p>
+                  <span>{lastName != "" ? lastName : "Unknown"}</span>
               </div>
             </div>
 
@@ -419,18 +382,8 @@ export default function EditProfile() {
                 <MapPin className="w-5 h-5 text-gray-600" />
               </div>
               <div className="flex-1">
-                <Input
-                  type="text"
-                  id="country"
-                  name="country"
-                  value={country}
-                  onChange={(e) => setCountry(e.target.value)}
-                  label="Country"
-                  placeholder="Ex: Country"
-                  borderColor="border-gray-300"
-                  focusBorderColor="focus:border-green-800"
-                  bgColor="bg-transparent"
-                />
+                <p className="text-sm text-500">Country</p>
+                  <span>{country != "" ? country : "Unknown"}</span>
               </div>
             </div>
 
@@ -439,18 +392,8 @@ export default function EditProfile() {
                 <Home className="w-5 h-5 text-gray-600" />
               </div>
               <div className="flex-1">
-                <Input
-                  type="text"
-                  id="village"
-                  name="village"
-                  value={village}
-                  onChange={(e) => setVillage(e.target.value)}
-                  label="Village"
-                  placeholder="Ex: Village"
-                  borderColor="border-gray-300"
-                  focusBorderColor="focus:border-green-800"
-                  bgColor="bg-transparent"
-                />
+                <p className="text-sm text-500">Village</p>
+                  <span>{village != "" ? village : "Unknown"}</span>
               </div>
             </div>
 
@@ -459,34 +402,10 @@ export default function EditProfile() {
                 <FileText className="w-5 h-5 text-gray-600" />
               </div>
               <div className="flex-1">
-                <p className="text-sm text-gray-500">Bio/Challenges faced</p>
-                <button
-                  onClick={handleOpenBioModal}
-                  className="w-full font-medium text-gray-900 bg-transparent border-b border-gray-300 p-2 text-left flex justify-between items-center"
-                >
+                <p className="text-sm text-500">Bio/Challenges faced</p>
                   <span className="truncate">
-                    {bio ? bio : "Add your bio or challenges..."}
+                    {bio ? bio : "Unknown"}
                   </span>
-                  <svg
-                    className="h-5 w-5 text-gray-400 flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                    />
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                    />
-                  </svg>
-                </button>
               </div>
             </div>
 
@@ -495,17 +414,8 @@ export default function EditProfile() {
                 <Calendar className="w-5 h-5 text-gray-600" />
               </div>
               <div className="flex-1">
-                <Input
-                  type="date"
-                  id="birthday"
-                  name="birthday"
-                  value={birthday}
-                  onChange={(e) => setBirthday(e.target.value)}
-                  label="Birthday"
-                  borderColor="border-gray-300"
-                  focusBorderColor="focus:border-green-800"
-                  bgColor="bg-transparent"
-                />
+                <p className="text-sm text-500">Birthday</p>
+                  <span>{birthday || "Unknown"}</span>
               </div>
             </div>
           </div>
@@ -521,26 +431,8 @@ export default function EditProfile() {
                 <GraduationCap className="w-5 h-5 text-gray-600" />
               </div>
               <div className="flex-1">
-                <p className="text-sm text-gray-500">Education level</p>
-                <button
-                  onClick={() => setIsEducationModalOpen(true)}
-                  className="w-full font-medium text-gray-900 bg-transparent border-b border-gray-300 p-2 text-left flex justify-between items-center"
-                >
-                  <span>{educationLevel || "Select education level"}</span>
-                  <svg
-                    className="h-5 w-5 text-gray-400"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 9l-7 7-7-7"
-                    />
-                  </svg>
-                </button>
+                <p className="text-sm text-500">Education level</p>
+                  <span>{educationLevel || "Unknown"}</span>
               </div>
             </div>
 
@@ -549,26 +441,8 @@ export default function EditProfile() {
                 <Users className="w-5 h-5 text-gray-600" />
               </div>
               <div className="flex-1">
-                <p className="text-sm text-gray-500">Guardian</p>
-                <button
-                  onClick={() => setIsGuardianModalOpen(true)}
-                  className="w-full font-medium text-gray-900 bg-transparent border-b border-gray-300 p-2 text-left flex justify-between items-center"
-                >
-                  <span>{guardian || "Select guardian"}</span>
-                  <svg
-                    className="h-5 w-5 text-gray-400"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 9l-7 7-7-7"
-                    />
-                  </svg>
-                </button>
+                <p className="text-sm text-500">Guardian</p>
+                  <span>{guardian || "Unknown"}</span>
               </div>
             </div>
 
@@ -577,26 +451,8 @@ export default function EditProfile() {
                 <Heart className="w-5 h-5 text-gray-600" />
               </div>
               <div className="flex-1">
-                <p className="text-sm text-gray-500">Is orphan</p>
-                <button
-                  onClick={() => setIsOrphanModalOpen(true)}
-                  className="w-full font-medium text-gray-900 bg-transparent border-b border-gray-300 p-2 text-left flex justify-between items-center"
-                >
-                  <span>{isOrphan || "Select option"}</span>
-                  <svg
-                    className="h-5 w-5 text-gray-400"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 9l-7 7-7-7"
-                    />
-                  </svg>
-                </button>
+                <p className="text-sm text-500">Is orphan</p>
+                  <span>{isOrphan || "Unknown"}</span>
               </div>
             </div>
           </div>
@@ -610,18 +466,8 @@ export default function EditProfile() {
                 <Briefcase className="w-5 h-5 text-gray-600" />
               </div>
               <div className="flex-1">
-                <Input
-                  type="text"
-                  id="dreamjob"
-                  name="dreamjob"
-                  value={dreamJob}
-                  onChange={(e) => setDreamJob(e.target.value)}
-                  label="Dream job"
-                  placeholder="Airplane pilot"
-                  borderColor="border-gray-300"
-                  focusBorderColor="focus:border-green-800"
-                  bgColor="bg-transparent"
-                />
+                <p className="text-sm text-500">Dream Job</p>
+                  <span>{dreamJob != "" ? dreamJob : "Unknown"}</span>
               </div>
             </div>
 
@@ -630,18 +476,8 @@ export default function EditProfile() {
                 <Square className="w-5 h-5 text-gray-600" />
               </div>
               <div className="flex-1">
-                <Input
-                  type="text"
-                  id="hobby"
-                  name="hobby"
-                  value={hobby}
-                  onChange={(e) => setHobby(e.target.value)}
-                  label="Hobby"
-                  placeholder="Dancing"
-                  borderColor="border-gray-300"
-                  focusBorderColor="focus:border-green-800"
-                  bgColor="bg-transparent"
-                />
+                <p className="text-sm text-500">Hobby</p>
+                  <span>{hobby != "" ? hobby : "Unknown"}</span>
               </div>
             </div>
           </div>
@@ -651,49 +487,10 @@ export default function EditProfile() {
             <div className="p-2 bg-gray-100 rounded-lg">
               <Palette className="w-5 h-5 text-gray-600" />
             </div>
-            <div className="flex-1">
-              <Input
-                type="text"
-                id="favoriteColor"
-                name="favoriteColor"
-                value={favoriteColor}
-                onChange={(e) => setFavoriteColor(e.target.value)}
-                label="Favorite Color"
-                placeholder="Ex: Blue"
-                borderColor="border-gray-300"
-                focusBorderColor="focus:border-green-800"
-                bgColor="bg-transparent"
-              />
-            </div>
-          </div>
-
-          <div className="flex justify-center">
-            <Link
-              href="/letterhome"
-              className="transition-transform hover:scale-105 focus:outline-none"
-              onClick={(e) => {
-                e.preventDefault();
-                saveProfileData().then(() => {
-                  router.push("/letterhome");
-                });
-              }}
-            >
-              <Button
-                btnType="button"
-                btnText={
-                  isSaving ? (
-                    <div className="inline-block animate-spin rounded-full h-4 w-4 border-t-2 border-b-2 border-gray-400"></div>
-                  ) : (
-                    "Save"
-                  )
-                }
-                color="bg-green-800"
-                hoverColor="hover:bg-[#48801c]"
-                textColor="text-gray-200"
-                disabled={isSaving}
-                rounded="rounded-full"
-              />
-            </Link>
+              <div className="flex-1">
+                <p className="text-sm text-500">Favorite Color</p>
+                  <span>{favoriteColor != "" ? favoriteColor : "Unknown"}</span>
+              </div>
           </div>
         </div>
       </div>

--- a/components/general/letter/ProfileHeader.jsx
+++ b/components/general/letter/ProfileHeader.jsx
@@ -2,10 +2,10 @@ import Link from "next/link";
 import ProfileImage from "../ProfileImage";
 import Button from "../Button";
 
-export default function ProfileHeader({ userName, country, profileImage }) {
+export default function ProfileHeader({ userName, country, profileImage, id }) {
   return (
     <header className="flex justify-between items-center bg-blue-100 p-5 border-b border-gray-200">
-      <Link href="/profile">
+      <Link href={"/profile-view/" + id}>
         <Button
           btnText={
             <div className="flex items-center">

--- a/components/general/letter/RecipientList.jsx
+++ b/components/general/letter/RecipientList.jsx
@@ -8,7 +8,7 @@ export default function RecipientList({ recipients }) {
   return (
     <div className="flex space-x-6 p-4 bg-[#F3F4F6] rounded-t-lg">
       {recipients.map(recipient => (
-        <Link href={"/profile-view/" + recipient?.id}>
+        <Link key={recipient?.id} href={"/profile-view/" + recipient?.id}>
         <div key={recipient?.first_name?.[0]} className="flex items-center space-x-3">
           <ProfileImage 
             photo_uri={recipient?.photo_uri} 

--- a/components/general/letter/RecipientList.jsx
+++ b/components/general/letter/RecipientList.jsx
@@ -1,29 +1,30 @@
 import Link from "next/link";
 import ProfileImage from "../ProfileImage";
 
-
 export default function RecipientList({ recipients }) {
   if (!recipients?.length) return null;
 
   return (
     <div className="flex space-x-6 p-4 bg-[#F3F4F6] rounded-t-lg">
-      {recipients.map(recipient => (
+      {recipients.map((recipient) => (
         <Link key={recipient?.id} href={"/profile-view/" + recipient?.id}>
-        <div key={recipient?.first_name?.[0]} className="flex items-center space-x-3">
-          <ProfileImage 
-            photo_uri={recipient?.photo_uri} 
-            first_name={recipient?.first_name} 
-            size={10}
-          />
-          <div>
-            <h2 className="font-bold text-sm text-black">
-              {recipient?.first_name} {recipient?.last_name}
-            </h2>
-            <p className="text-xs text-gray-500">{recipient?.country}</p>
+          <div
+            className="flex items-center space-x-3"
+          >
+            <ProfileImage
+              photo_uri={recipient?.photo_uri}
+              first_name={recipient?.first_name}
+              size={10}
+            />
+            <div>
+              <h2 className="font-bold text-sm text-black">
+                {recipient?.first_name} {recipient?.last_name}
+              </h2>
+              <p className="text-xs text-gray-500">{recipient?.country}</p>
+            </div>
           </div>
-        </div>
         </Link>
       ))}
     </div>
   );
-} 
+}

--- a/components/general/letter/RecipientList.jsx
+++ b/components/general/letter/RecipientList.jsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import ProfileImage from "../ProfileImage";
 
 
@@ -7,6 +8,7 @@ export default function RecipientList({ recipients }) {
   return (
     <div className="flex space-x-6 p-4 bg-[#F3F4F6] rounded-t-lg">
       {recipients.map(recipient => (
+        <Link href={"/profile-view/" + recipient?.id}>
         <div key={recipient?.first_name?.[0]} className="flex items-center space-x-3">
           <ProfileImage 
             photo_uri={recipient?.photo_uri} 
@@ -20,6 +22,7 @@ export default function RecipientList({ recipients }) {
             <p className="text-xs text-gray-500">{recipient?.country}</p>
           </div>
         </div>
+        </Link>
       ))}
     </div>
   );

--- a/components/general/profile/InfoDisplay.jsx
+++ b/components/general/profile/InfoDisplay.jsx
@@ -1,0 +1,13 @@
+export default function InfoDisplay({children, title, info = ""}) {
+  return (
+    <div className="flex items-center gap-3">
+      <div className="p-2 rounded-lg">{children}</div>
+      <div className="flex-1">
+        <p className="text-sm text-gray-500">{title}</p>
+        <span className={info != "" ? "" : "text-gray-500"}>
+          {info != "" ? info : "Unknown"}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/components/general/profile/ProfileSection.jsx
+++ b/components/general/profile/ProfileSection.jsx
@@ -1,0 +1,10 @@
+export default function ProfileSection ({ children, title }) {
+  return (
+    <div className="space-y-4">
+      <div className="h-4"></div>
+      <h3 className="text-blue-900 font-medium text-sm mb-5">{title}</h3>
+      <div className="h-4"></div>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
added a link to profile-view/[id] for the User from lettershome in the ProfileHeader and added button to edit profile from profile-view if it's the current user's profile (from Figma). I also updated the UI in profile-view/[id] to match the Figma examples. You can view other users' profiles (Rez) from the letters/[id] page by clicking on the recipient list item which is now a link to profile-view/[id]