### PR TITLE
Build Error Fix: Wrapped NavigationStateManager in a Suspense boundary in layout.js

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -1,7 +1,8 @@
 import { Inter } from 'next/font/google'
 import './globals.css'
 import NavigationStateManager from '../components/loading/NavigationStateManager'
-
+import { Suspense } from 'react'
+import LoadingSpinner from '../components/loading/LoadingSpinner'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -14,8 +15,10 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className={inter.className}>
-        <NavigationStateManager />
+        <Suspense fallback={<LoadingSpinner />}>
+          <NavigationStateManager />
           {children}
+        </Suspense>          
       </body>
     </html>
   )


### PR DESCRIPTION
FIX: Generating static pages (0/23)  [    ] ⨯ useSearchParams() should be wrapped in a suspense boundary at page "/privacy-policy". Read more: https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout Generating static pages (0/23)  [    ] ⨯ useSearchParams() should be wrapped in a suspense boundary at page "/privacy-policy". Read more: https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout