### PR TITLE
Sorted conversation list

### DIFF
--- a/app/letterhome/page.js
+++ b/app/letterhome/page.js
@@ -71,7 +71,7 @@ export default function Home() {
             }`,
             country: recipient.country ?? "Unknown",
             lastMessage: letter.content || "",
-            lastMessageDate: letter.created_at || "",
+            lastMessageDate: letter.drafted_at || letter.updated_at || "",
             status: letter.status || "",
             letterboxId: id || "",
             isRecipient: letter?.sent_by?.id !== uid,
@@ -79,6 +79,13 @@ export default function Home() {
           };
         })
       );
+
+      // sort the conversations by the last message date
+      fetchedConversations.sort((a, b) => {
+        const dateA = a.lastMessageDate?.toDate?.() || a.lastMessageDate || new Date(0);
+        const dateB = b.lastMessageDate?.toDate?.() || b.lastMessageDate || new Date(0);
+        return dateB - dateA;
+      });
 
       return fetchedConversations;
     } catch (err) {


### PR DESCRIPTION
Added sorting for the conversation list through drafted_at (new documents) and updated_at (old documents)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation ordering has been improved to provide a more intuitive experience. Conversations now sort by their most recent draft or update timestamp, rather than creation time, ensuring you can quickly locate and access active conversations without scrolling through older items in your list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->