### PR TITLE
Fix remaining updated_at changes

### DIFF
--- a/app/letters/[id]/page.js
+++ b/app/letters/[id]/page.js
@@ -38,6 +38,7 @@ const fetchDraft = async (letterboxId, userRef, shouldCreate = false) => {
     const letterboxRef = doc(db, "letterbox", letterboxId);
     const lettersRef = collection(letterboxRef, "letters");
 
+    // Retain the old query for existing documents
     const draftQuery = query(
       lettersRef,
       where("sent_by", "==", userRef),
@@ -357,7 +358,6 @@ export default function Page({ params }) {
             return {
               ...msg,
               content: trimmedContent,
-              updated_at: currentTime,
               drafted_at: currentTime,
             };
           }
@@ -716,7 +716,6 @@ export default function Page({ params }) {
                 id: docSnap.id,
                 ...docSnap.data(),
                 created_at: docSnap.data().created_at?.toDate(),
-                updated_at: docSnap.data().updated_at?.toDate(),
                 drafted_at: docSnap.data().drafted_at?.toDate(),
               };
       

--- a/app/letters/[id]/page.js
+++ b/app/letters/[id]/page.js
@@ -57,6 +57,8 @@ const fetchDraft = async (letterboxId, userRef, shouldCreate = false) => {
           draftDoc.data().created_at?.toDate?.() || draftDoc.data().created_at,
         updated_at:
           draftDoc.data().updated_at?.toDate?.() || draftDoc.data().updated_at,
+        drafted_at:
+          draftDoc.data().drafted_at?.toDate?.() || draftDoc.data().drafted_at,
       };
 
       return draftData;
@@ -69,6 +71,7 @@ const fetchDraft = async (letterboxId, userRef, shouldCreate = false) => {
         status: "draft",
         created_at: new Date(),
         updated_at: new Date(),
+        drafted_at: new Date(),
         deleted: null,
         unread: true,
       };
@@ -166,6 +169,7 @@ export default function Page({ params }) {
           content: trimmedContent,
           status: "draft",
           updated_at: currentTime,
+          drafted_at: currentTime,
           deleted: null,
           unread: true,
         };
@@ -313,6 +317,7 @@ export default function Page({ params }) {
       const updateData = {
         content: trimmedContent,
         updated_at: currentTime,
+        drafted_at: currentTime,
       };
 
       await updateDoc(messageRef, updateData);
@@ -343,6 +348,7 @@ export default function Page({ params }) {
               ...msg,
               content: trimmedContent,
               updated_at: currentTime,
+              drafted_at: currentTime,
             };
           }
           return msg;
@@ -402,6 +408,7 @@ export default function Page({ params }) {
         status: "pending_review",
         created_at: currentTime,
         updated_at: currentTime,
+        drafted_at: currentTime,
         deleted: null,
         unread: true,
       };
@@ -701,6 +708,7 @@ export default function Page({ params }) {
                 ...docSnap.data(),
                 created_at: docSnap.data().created_at?.toDate(),
                 updated_at: docSnap.data().updated_at?.toDate(),
+                drafted_at: docSnap.data().drafted_at?.toDate(),
               };
       
               // Normalize Firestore DocumentReference → { id }

--- a/app/letters/[id]/page.js
+++ b/app/letters/[id]/page.js
@@ -46,7 +46,19 @@ const fetchDraft = async (letterboxId, userRef, shouldCreate = false) => {
       limit(1)
     );
 
-    const draftSnapshot = await getDocs(draftQuery);
+    let draftSnapshot = await getDocs(draftQuery);
+
+    // Add fallback query for drafts with drafted_at
+    if (draftSnapshot.empty) {
+      const fallbackDraftQuery = query (
+        lettersRef,
+        where("sent_by", "==", userRef),
+        where("status", "==", "draft"),
+        orderBy("drafted_at", "desc"),
+        limit(1)
+      );
+      draftSnapshot = await getDocs(fallbackDraftQuery);
+    }
 
     if (!draftSnapshot.empty) {
       const draftDoc = draftSnapshot.docs[0];
@@ -55,10 +67,11 @@ const fetchDraft = async (letterboxId, userRef, shouldCreate = false) => {
         ...draftDoc.data(),
         created_at:
           draftDoc.data().created_at?.toDate?.() || draftDoc.data().created_at,
-        updated_at:
-          draftDoc.data().updated_at?.toDate?.() || draftDoc.data().updated_at,
         drafted_at:
-          draftDoc.data().drafted_at?.toDate?.() || draftDoc.data().drafted_at,
+          draftDoc.data().drafted_at?.toDate?.() || 
+          draftDoc.data().updated_at?.toDate?.() ||
+          draftDoc.data().drafted_at ||
+          draftDoc.data().updated_at,
       };
 
       return draftData;
@@ -70,7 +83,6 @@ const fetchDraft = async (letterboxId, userRef, shouldCreate = false) => {
         content: "",
         status: "draft",
         created_at: new Date(),
-        updated_at: new Date(),
         drafted_at: new Date(),
         deleted: null,
         unread: true,
@@ -168,7 +180,6 @@ export default function Page({ params }) {
           sent_by: letterUserRef,
           content: trimmedContent,
           status: "draft",
-          updated_at: currentTime,
           drafted_at: currentTime,
           deleted: null,
           unread: true,
@@ -316,7 +327,6 @@ export default function Page({ params }) {
 
       const updateData = {
         content: trimmedContent,
-        updated_at: currentTime,
         drafted_at: currentTime,
       };
 
@@ -407,7 +417,6 @@ export default function Page({ params }) {
         content: trimmedContent,
         status: "pending_review",
         created_at: currentTime,
-        updated_at: currentTime,
         drafted_at: currentTime,
         deleted: null,
         unread: true,

--- a/app/letters/[id]/page.js
+++ b/app/letters/[id]/page.js
@@ -67,10 +67,9 @@ const fetchDraft = async (letterboxId, userRef, shouldCreate = false) => {
         id: draftDoc.id,
         ...draftDoc.data(),
         created_at:
-          draftDoc.data().created_at?.toDate?.() || draftDoc.data().created_at,
+          draftDoc.data().created_at?.toDate?.() || null,
         drafted_at:
-          draftDoc.data().drafted_at?.toDate?.() || 
-          draftDoc.data().drafted_at,
+          draftDoc.data().drafted_at?.toDate?.() || null,
       };
 
       return draftData;

--- a/app/letters/[id]/page.js
+++ b/app/letters/[id]/page.js
@@ -70,9 +70,7 @@ const fetchDraft = async (letterboxId, userRef, shouldCreate = false) => {
           draftDoc.data().created_at?.toDate?.() || draftDoc.data().created_at,
         drafted_at:
           draftDoc.data().drafted_at?.toDate?.() || 
-          draftDoc.data().updated_at?.toDate?.() ||
-          draftDoc.data().drafted_at ||
-          draftDoc.data().updated_at,
+          draftDoc.data().drafted_at,
       };
 
       return draftData;

--- a/app/utils/letterboxFunctions.js
+++ b/app/utils/letterboxFunctions.js
@@ -202,28 +202,40 @@ export const fetchLatestLetterFromLetterbox = async (letterboxId, userRef) => {
   const letterboxRef = doc(collection(db, "letterbox"), letterboxId);
   const lRef = collection(letterboxRef, "letters");
 
-  // My Letters
-  const userLettersQuery = query(
-    lRef,
-    where("sent_by", "==", userRef),
-    where("content", "!=", ""),
-    orderBy("updated_at", "desc"),
-    limit(1) // grab a few in case of fallback
-  );
+  // Query with fallback in case no result for drafted_at
+  const getLatestByFieldFallback = async (constraints) => {
 
-  // Your letters
-  const sentLettersQuery = query(
-    lRef,
-    where("status", "==", "sent"),
-    where("content", "!=", ""),
-    orderBy("updated_at", "desc"),
-    limit(1)
-  );
+    const draftedQuery = query (
+      lRef,
+      ...constraints,
+      orderBy("drafted_at", "desc"),
+      limit(1)
+    );
+    
+    const draftedSnap = await getDocs(draftedQuery);
+    
+    if (!draftedSnap.empty) return draftedSnap;
+
+    const updatedQuery = query(
+      lRef,
+      ...constraints,
+      orderBy("updated_at", "desc"),
+      limit(1)
+    );
+
+    return getDocs(updatedQuery);
+  };
 
   // Run both in parallel
   const [userLettersSnap, sentLettersSnap] = await Promise.all([
-    getDocs(userLettersQuery),
-    getDocs(sentLettersQuery),
+    getLatestByFieldFallback([
+      where("sent_by", "==", userRef),
+      where("content", "!=", ""),
+    ]),
+    getLatestByFieldFallback([
+      where("status", "==", "sent"),
+      where("content", "!=", ""),
+    ]),
   ]);
 
   const allLetters = [];
@@ -238,7 +250,6 @@ export const fetchLatestLetterFromLetterbox = async (letterboxId, userRef) => {
       if (doc?.data()?.sent_by?.id !== userRef?.id)
         allLetters.push({ id: doc?.id, ...doc?.data() });
     });
-
   // Use drafted_at for new docs, and updated_at for old as fallback
   const getLetterDate = (letter) => 
     letter?.drafted_at?.toDate?.() ||

--- a/app/utils/letterboxFunctions.js
+++ b/app/utils/letterboxFunctions.js
@@ -215,17 +215,7 @@ export const fetchLatestLetterFromLetterbox = async (letterboxId, userRef) => {
     
     const draftedSnap = await getDocs(draftedQuery);
     
-    if (!draftedSnap.empty) return draftedSnap;
-
-    // fallback query in case drafted_at is not found, usually for old or existing documents
-    const updatedQuery = query(
-      lRef,
-      ...constraints,
-      orderBy("updated_at", "desc"),
-      limit(1)
-    );
-
-    return getDocs(updatedQuery);
+    return draftedSnap;
   };
 
   // Run both in parallel
@@ -252,10 +242,9 @@ export const fetchLatestLetterFromLetterbox = async (letterboxId, userRef) => {
       if (doc?.data()?.sent_by?.id !== userRef?.id)
         allLetters.push({ id: doc?.id, ...doc?.data() });
     });
-  // Use drafted_at for new docs, and updated_at for old as fallback
+  // Use drafted_at for new docs, and created_at for old as fallback
   const getLetterDate = (letter) => 
     letter?.drafted_at?.toDate?.() ||
-    letter?.updated_at?.toDate?.() ||
     letter?.created_at?.toDate?.() ||
     new Date(0);
   

--- a/app/utils/letterboxFunctions.js
+++ b/app/utils/letterboxFunctions.js
@@ -205,6 +205,7 @@ export const fetchLatestLetterFromLetterbox = async (letterboxId, userRef) => {
   // Query with fallback in case no result for drafted_at
   const getLatestByFieldFallback = async (constraints) => {
 
+    // initial query to check existence of the new field drafted_at
     const draftedQuery = query (
       lRef,
       ...constraints,
@@ -216,6 +217,7 @@ export const fetchLatestLetterFromLetterbox = async (letterboxId, userRef) => {
     
     if (!draftedSnap.empty) return draftedSnap;
 
+    // fallback query in case drafted_at is not found, usually for old or existing documents
     const updatedQuery = query(
       lRef,
       ...constraints,
@@ -375,7 +377,7 @@ export const createConnection = async (userDocRef, kidDocRef) => {
               sent_by: userDocRef,
               content: "Please complete your first letter here...",
               status: "draft",
-              updated_at: new Date(),
+              drafted_at: new Date(),
               created_at: new Date(),
               deleted: null
             });

--- a/app/utils/letterboxFunctions.js
+++ b/app/utils/letterboxFunctions.js
@@ -239,14 +239,20 @@ export const fetchLatestLetterFromLetterbox = async (letterboxId, userRef) => {
         allLetters.push({ id: doc?.id, ...doc?.data() });
     });
 
+  // Use drafted_at for new docs, and updated_at for old as fallback
+  const getLetterDate = (letter) => 
+    letter?.drafted_at?.toDate?.() ||
+    letter?.updated_at?.toDate?.() ||
+    letter?.created_at?.toDate?.() ||
+    new Date(0);
+  
+
   if (allLetters.length === 0) return null;
-  else if (allLetters.length === 1) return allLetters[0];
-  else if (
-    allLetters[0]?.updated_at?.toDate?.() >
-    allLetters[1]?.updated_at?.toDate?.()
-  )
-    return allLetters[0];
-  else return allLetters[1];
+  if (allLetters.length === 1) return allLetters[0];
+  
+  return getLetterDate(allLetters[0]) > getLetterDate(allLetters[1]) 
+      ? allLetters[0] 
+      : allLetters[1];
 };
 
 export const fetchRecipients = async (id) => {


### PR DESCRIPTION
Replace reference of updated_at to drafted_at. For fallback, updated_at field is still used and drafted_at for new documents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drafts and pending-review messages now record and expose a dedicated draft timestamp ("drafted_at") and the UI surfaces this timestamp in message timelines.

* **Bug Fixes**
  * Retrieval now prefers the most recent draft timestamp and falls back to other timestamps so the latest draft reliably appears.
  * Message timestamp handling normalized for consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->