### PR TITLE
Prefill rejection reason and feedback when editing rejected letters

### DIFF
--- a/components/general/admin/AdminRejectModal.jsx
+++ b/components/general/admin/AdminRejectModal.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import rejectionReasons from "./rejectionReasons";
 import { ChevronLeft } from "lucide-react";
 import LoadingSpinner from "../../loading/LoadingSpinner";
@@ -10,6 +10,13 @@ export default function AdminRejectModal({ letter, onSubmit, onClose }) {
   const [feedback, setFeedback] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState("");
+
+  useEffect(() => {
+  if (!letter) return;
+
+  setReason(letter.rejection_reason || "");
+  setFeedback(letter.rejection_feedback || "");
+}, [letter]);
 
   const handleReasonSelect = (selectedReason) => {
     setReason(selectedReason);


### PR DESCRIPTION
Summary

This PR improves the admin rejection edit flow by preloading the previously selected rejection reason and rejection feedback when editing a rejected letter.

Changes
Added useEffect in AdminRejectModal
Pre-filled:
rejection_reason
rejection_feedback
Prevents admins from having to re-enter rejection details from scratch when clicking Edit
UX Improvement

Admins can now edit rejected letters more efficiently while preserving the original moderation context.