### PR TITLE
Replace ffmpeg media compression with browser-native helper

### DIFF
--- a/app/media/page.js
+++ b/app/media/page.js
@@ -10,6 +10,7 @@ import AudioPlayer from "../../components/media/AudioPlayer";
 import VideoUploader from "../../components/media/VideoUploader";
 import VideoPlayer from "../../components/media/VideoPlayer";
 import ImageUploader from "../../components/media/ImageUploader";
+import useBeforeUnloadWarning from "../../components/media/useBeforeUnloadWarning";
 /**
  *
  * // Audio and Video compression test
@@ -19,6 +20,74 @@ export default function LocalDownload() {
   const [audioContent, setAudioContent] = useState("");
   const [videoContent, setVideoContent] = useState("");
   const [imgContent, setImgContent] = useState("");
+  const [isCompressing, setIsCompressing] = useState(false);
+  const [testFile, setTestFile] = useState(null);
+  const [testResult, setTestResult] = useState(null);
+  const [testError, setTestError] = useState("");
+
+  useBeforeUnloadWarning(isCompressing);
+
+  const formatSize = (bytes) => {
+    if (!bytes) return "0 KB";
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(2)} KB`;
+    return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+  };
+
+  const getExtensionFromMimeType = (mimeType) => {
+    const baseType = mimeType.split(";")[0];
+    const extensionMap = {
+      "audio/mpeg": "mp3",
+      "audio/mp3": "mp3",
+      "audio/mp4": "m4a",
+      "audio/ogg": "ogg",
+      "audio/webm": "webm",
+      "video/mp4": "mp4",
+      "video/webm": "webm",
+      "image/jpeg": "jpg",
+      "image/png": "png",
+      "image/webp": "webp",
+    };
+
+    return extensionMap[baseType] || baseType.split("/")[1] || "bin";
+  };
+
+  const clearTestResult = () => {
+    if (testResult?.url) URL.revokeObjectURL(testResult.url);
+    setTestResult(null);
+  };
+
+  async function handleCompressionTest(e) {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+
+    clearTestResult();
+    setTestFile(file ?? null);
+    setTestError("");
+    setProgress(0);
+
+    if (!file) return;
+
+    try {
+      setIsCompressing(true);
+      const compressedBlob = await compressMedia(file, (p) =>
+        setProgress(Math.round(p * 100)),
+      );
+
+      const url = URL.createObjectURL(compressedBlob);
+      setTestResult({
+        blob: compressedBlob,
+        url,
+        fileName: `compressed_${Date.now()}.${getExtensionFromMimeType(
+          compressedBlob.type,
+        )}`,
+      });
+    } catch (error) {
+      console.error("Compression test failed:", error);
+      setTestError(error.message || "Compression failed");
+    } finally {
+      setIsCompressing(false);
+    }
+  }
 
 
   const handleRequireLogin = () => {
@@ -47,6 +116,91 @@ export default function LocalDownload() {
 
   return (
     <div className="p-4 flex flex-col justify-center items-center gap-4">
+      <section className="w-full max-w-xl rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="mb-3">
+          <h1 className="text-lg font-semibold text-slate-800">
+            Local Compression Test
+          </h1>
+          <p className="text-sm text-slate-500">
+            Runs compressMedia in this browser only. Nothing is uploaded.
+          </p>
+        </div>
+
+        <label className="flex cursor-pointer items-center justify-center rounded-md border border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-sm font-medium text-slate-600 hover:bg-slate-100">
+          Choose photo, video, or audio
+          <input
+            type="file"
+            accept="image/*,video/*,audio/*"
+            className="hidden"
+            onChange={handleCompressionTest}
+            disabled={isCompressing}
+          />
+        </label>
+
+        {(testFile || isCompressing || testError) && (
+          <div className="mt-4 space-y-3 text-sm text-slate-700">
+            {testFile && (
+              <div className="grid grid-cols-2 gap-2 rounded-md bg-slate-50 p-3">
+                <span>Original</span>
+                <span className="text-right font-medium">
+                  {formatSize(testFile.size)}
+                </span>
+                <span>Compressed</span>
+                <span className="text-right font-medium">
+                  {testResult ? formatSize(testResult.blob.size) : "-"}
+                </span>
+              </div>
+            )}
+
+            {isCompressing && (
+              <div>
+                <div className="mb-1 flex justify-between text-xs text-slate-500">
+                  <span>Compressing</span>
+                  <span>{progress}%</span>
+                </div>
+                <div className="h-2 overflow-hidden rounded-full bg-slate-100">
+                  <div
+                    className="h-full rounded-full bg-indigo-600 transition-all"
+                    style={{ width: `${progress}%` }}
+                  />
+                </div>
+              </div>
+            )}
+
+            {testError && <p className="text-red-600">{testError}</p>}
+
+            {testResult && (
+              <div className="space-y-3">
+                {testResult.blob.type.startsWith("image") && (
+                  <img
+                    src={testResult.url}
+                    alt="Compressed preview"
+                    className="max-h-72 w-full rounded-md bg-slate-100 object-contain"
+                  />
+                )}
+                {testResult.blob.type.startsWith("video") && (
+                  <video
+                    src={testResult.url}
+                    controls
+                    className="max-h-72 w-full rounded-md bg-black"
+                  />
+                )}
+                {testResult.blob.type.startsWith("audio") && (
+                  <audio src={testResult.url} controls className="w-full" />
+                )}
+                <a
+                  href={testResult.url}
+                  download={testResult.fileName}
+                  className="inline-flex rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                >
+                  Download compressed file
+                </a>
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+
       <div>
         <AudioPlayer src={audioContent} />
       </div>

--- a/app/media/page.js
+++ b/app/media/page.js
@@ -3,7 +3,10 @@
 import React, { useState } from "react";
 import { Film, Image as ImageIcon } from "lucide-react";
 
-import { compressMedia } from "../utils/compressMedia";
+import {
+  compressMedia,
+  getDetectedCompressionProfile,
+} from "../utils/compressMedia";
 
 import AudioRecorder from "../../components/media/AudioRecorder"
 import AudioPlayer from "../../components/media/AudioPlayer";
@@ -24,6 +27,8 @@ export default function LocalDownload() {
   const [testFile, setTestFile] = useState(null);
   const [testResult, setTestResult] = useState(null);
   const [testError, setTestError] = useState("");
+  const [selectedProfile, setSelectedProfile] = useState("auto");
+  const detectedProfile = getDetectedCompressionProfile();
 
   useBeforeUnloadWarning(isCompressing);
 
@@ -69,8 +74,10 @@ export default function LocalDownload() {
 
     try {
       setIsCompressing(true);
-      const compressedBlob = await compressMedia(file, (p) =>
-        setProgress(Math.round(p * 100)),
+      const compressedBlob = await compressMedia(
+        file,
+        (p) => setProgress(Math.round(p * 100)),
+        selectedProfile === "auto" ? {} : { profile: selectedProfile },
       );
 
       const url = URL.createObjectURL(compressedBlob);
@@ -124,6 +131,29 @@ export default function LocalDownload() {
           <p className="text-sm text-slate-500">
             Runs compressMedia in this browser only. Nothing is uploaded.
           </p>
+        </div>
+
+        <div className="mb-3 grid gap-2 rounded-md bg-slate-50 p-3 text-sm text-slate-700">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <span>Detected profile</span>
+            <span className="rounded bg-white px-2 py-1 font-medium text-slate-800">
+              {detectedProfile}
+            </span>
+          </div>
+          <label className="flex flex-wrap items-center justify-between gap-2">
+            <span>Test with profile</span>
+            <select
+              value={selectedProfile}
+              onChange={(e) => setSelectedProfile(e.target.value)}
+              disabled={isCompressing}
+              className="rounded border border-slate-300 bg-white px-2 py-1 text-slate-800"
+            >
+              <option value="auto">Auto ({detectedProfile})</option>
+              <option value="lowEnd">lowEnd</option>
+              <option value="balanced">balanced</option>
+              <option value="capable">capable</option>
+            </select>
+          </label>
         </div>
 
         <label className="flex cursor-pointer items-center justify-center rounded-md border border-dashed border-slate-300 bg-slate-50 px-4 py-6 text-sm font-medium text-slate-600 hover:bg-slate-100">

--- a/app/utils/compressMedia.js
+++ b/app/utils/compressMedia.js
@@ -17,6 +17,45 @@ const AUDIO_MIME_TYPES = [
   "audio/mpeg",
 ];
 
+const KB = 1024;
+const MB = 1024 * KB;
+
+const COMPRESSION_PROFILES = {
+  lowEnd: {
+    imageMaxSizeMB: 0.75,
+    imageMaxWidthOrHeight: 1024,
+    imageQuality: 0.65,
+    videoMaxWidth: 480,
+    videoFps: 12,
+    videoBitsPerSecond: 450000,
+    audioBitsPerSecond: 48000,
+    audioSkipBelowBytes: 500 * KB,
+    videoSkipBelowBytes: 5 * MB,
+  },
+  balanced: {
+    imageMaxSizeMB: 1,
+    imageMaxWidthOrHeight: 1280,
+    imageQuality: 0.72,
+    videoMaxWidth: 640,
+    videoFps: 15,
+    videoBitsPerSecond: 650000,
+    audioBitsPerSecond: 56000,
+    audioSkipBelowBytes: 500 * KB,
+    videoSkipBelowBytes: 8 * MB,
+  },
+  capable: {
+    imageMaxSizeMB: 1.25,
+    imageMaxWidthOrHeight: 1600,
+    imageQuality: 0.78,
+    videoMaxWidth: 854,
+    videoFps: 20,
+    videoBitsPerSecond: 900000,
+    audioBitsPerSecond: 64000,
+    audioSkipBelowBytes: 500 * KB,
+    videoSkipBelowBytes: 10 * MB,
+  },
+};
+
 const clampProgress = (progress) => Math.min(1, Math.max(0, progress));
 
 const reportProgress = (onProgress, progress) => {
@@ -42,6 +81,38 @@ const chooseSmallerMedia = (originalFile, compressedBlob) => {
   return compressedBlob;
 };
 
+const finishWithOriginal = (file, onProgress) => {
+  reportProgress(onProgress, 1);
+  return file;
+};
+
+const getDeviceProfileName = () => {
+  if (typeof navigator === "undefined") return "balanced";
+
+  const cores = navigator.hardwareConcurrency || 4;
+  const memory = navigator.deviceMemory || 4;
+  const isMobile =
+    /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent) ||
+    navigator.maxTouchPoints > 1;
+
+  if (cores <= 2 || memory <= 2) return "lowEnd";
+  if (cores <= 4 || memory <= 4 || isMobile) return "balanced";
+  return "capable";
+};
+
+const getAdaptiveOptions = (customOptions) => {
+  const profileName = customOptions.profile || getDeviceProfileName();
+  const profile =
+    COMPRESSION_PROFILES[profileName] || COMPRESSION_PROFILES.balanced;
+
+  return {
+    ...profile,
+    ...customOptions,
+  };
+};
+
+export const getDetectedCompressionProfile = getDeviceProfileName;
+
 const waitForMetadata = (mediaElement) =>
   new Promise((resolve, reject) => {
     mediaElement.onloadedmetadata = resolve;
@@ -64,8 +135,11 @@ const compressImage = async (file, onProgress, options) => {
 
 const compressAudio = async (file, onProgress, options) => {
   if (typeof MediaRecorder === "undefined") {
-    reportProgress(onProgress, 1);
-    return file;
+    return finishWithOriginal(file, onProgress);
+  }
+
+  if (file.size < options.audioSkipBelowBytes) {
+    return finishWithOriginal(file, onProgress);
   }
 
   const audio = document.createElement("audio");
@@ -91,8 +165,7 @@ const compressAudio = async (file, onProgress, options) => {
     }
 
     if (!stream) {
-      reportProgress(onProgress, 1);
-      return file;
+      return finishWithOriginal(file, onProgress);
     }
 
     const mimeType = getSupportedMimeType(AUDIO_MIME_TYPES);
@@ -116,8 +189,11 @@ const compressAudio = async (file, onProgress, options) => {
 
 const compressVideo = async (file, onProgress, options) => {
   if (typeof MediaRecorder === "undefined") {
-    reportProgress(onProgress, 1);
-    return file;
+    return finishWithOriginal(file, onProgress);
+  }
+
+  if (file.size < options.videoSkipBelowBytes) {
+    return finishWithOriginal(file, onProgress);
   }
 
   const video = document.createElement("video");
@@ -142,8 +218,7 @@ const compressVideo = async (file, onProgress, options) => {
     canvas.height = height;
 
     if (!canvas.captureStream) {
-      reportProgress(onProgress, 1);
-      return file;
+      return finishWithOriginal(file, onProgress);
     }
 
     const canvasStream = canvas.captureStream(options.videoFps);
@@ -237,17 +312,7 @@ const recordMedia = ({
  * compressMedia(file, onProgress, customOptions)
  */
 export async function compressMedia(file, onProgress = null, customOptions = {}) {
-  const defaultOptions = {
-    imageMaxSizeMB: 1,
-    imageMaxWidthOrHeight: 1280,
-    imageQuality: 0.72,
-    videoMaxWidth: 854,
-    videoFps: 15,
-    videoBitsPerSecond: 700000,
-    audioBitsPerSecond: 64000,
-  };
-
-  const options = { ...defaultOptions, ...customOptions };
+  const options = getAdaptiveOptions(customOptions);
   reportProgress(onProgress, 0);
 
   if (file.type.startsWith("image")) {

--- a/app/utils/compressMedia.js
+++ b/app/utils/compressMedia.js
@@ -1,137 +1,266 @@
 "use client";
-import { FFmpeg } from "@ffmpeg/ffmpeg";
-import { fetchFile } from "@ffmpeg/util";
 
-let ffmpegInstance = null;
+import imageCompression from "browser-image-compression";
 
-async function getFFmpeg() {
-  if (ffmpegInstance) {
-    return ffmpegInstance;
+const VIDEO_MIME_TYPES = [
+  "video/mp4;codecs=h264,aac",
+  "video/mp4",
+  "video/webm;codecs=vp9,opus",
+  "video/webm;codecs=vp8,opus",
+  "video/webm",
+];
+
+const AUDIO_MIME_TYPES = [
+  "audio/webm;codecs=opus",
+  "audio/webm",
+  "audio/mp4",
+  "audio/mpeg",
+];
+
+const clampProgress = (progress) => Math.min(1, Math.max(0, progress));
+
+const reportProgress = (onProgress, progress) => {
+  if (onProgress) onProgress(clampProgress(progress));
+};
+
+const getSupportedMimeType = (mimeTypes) => {
+  if (typeof MediaRecorder === "undefined") return "";
+  return mimeTypes.find((mimeType) => MediaRecorder.isTypeSupported(mimeType)) ?? "";
+};
+
+const getCaptureStream = (mediaElement) => {
+  if (mediaElement.captureStream) return mediaElement.captureStream();
+  if (mediaElement.mozCaptureStream) return mediaElement.mozCaptureStream();
+  return null;
+};
+
+const chooseSmallerMedia = (originalFile, compressedBlob) => {
+  if (!compressedBlob?.size || compressedBlob.size >= originalFile.size) {
+    return originalFile;
   }
 
-  const ffmpeg = new FFmpeg({ log: true });
+  return compressedBlob;
+};
 
-  console.log("Loading ffmpeg-core.wasm...");
+const waitForMetadata = (mediaElement) =>
+  new Promise((resolve, reject) => {
+    mediaElement.onloadedmetadata = resolve;
+    mediaElement.onerror = () => reject(new Error("Unable to load media file."));
+  });
+
+const compressImage = async (file, onProgress, options) => {
+  const compressedFile = await imageCompression(file, {
+    maxSizeMB: options.imageMaxSizeMB,
+    maxWidthOrHeight: options.imageMaxWidthOrHeight,
+    initialQuality: options.imageQuality,
+    useWebWorker: true,
+    onProgress: (progress) => reportProgress(onProgress, progress / 100),
+    ...options.imageCompressionOptions,
+  });
+
+  reportProgress(onProgress, 1);
+  return compressedFile;
+};
+
+const compressAudio = async (file, onProgress, options) => {
+  if (typeof MediaRecorder === "undefined") {
+    reportProgress(onProgress, 1);
+    return file;
+  }
+
+  const audio = document.createElement("audio");
+  const objectUrl = URL.createObjectURL(file);
+  let audioContext = null;
+
   try {
-    await ffmpeg.load();
-    console.log("FFmpeg core loaded!");
-    ffmpegInstance = ffmpeg;
-    return ffmpegInstance;
-  } catch (error) {
-    console.error("Loading FFmpeg core error:", error);
-    ffmpegInstance = null;
-    return null;
+    audio.src = objectUrl;
+    audio.preload = "metadata";
+    await waitForMetadata(audio);
+
+    const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+    let stream = null;
+
+    if (AudioContextClass) {
+      audioContext = new AudioContextClass();
+      const source = audioContext.createMediaElementSource(audio);
+      const destination = audioContext.createMediaStreamDestination();
+      source.connect(destination);
+      stream = destination.stream;
+    } else {
+      stream = getCaptureStream(audio);
+    }
+
+    if (!stream) {
+      reportProgress(onProgress, 1);
+      return file;
+    }
+
+    const mimeType = getSupportedMimeType(AUDIO_MIME_TYPES);
+    const mediaRecorder = new MediaRecorder(stream, {
+      ...(mimeType ? { mimeType } : {}),
+      audioBitsPerSecond: options.audioBitsPerSecond,
+    });
+
+    return await recordMedia({
+      mediaElement: audio,
+      mediaRecorder,
+      onProgress,
+      fallbackType: file.type,
+      onStart: () => audioContext?.resume?.(),
+      onCleanup: () => audioContext?.close?.(),
+    });
+  } finally {
+    URL.revokeObjectURL(objectUrl);
   }
-}
+};
+
+const compressVideo = async (file, onProgress, options) => {
+  if (typeof MediaRecorder === "undefined") {
+    reportProgress(onProgress, 1);
+    return file;
+  }
+
+  const video = document.createElement("video");
+  const objectUrl = URL.createObjectURL(file);
+
+  try {
+    video.src = objectUrl;
+    video.muted = true;
+    video.playsInline = true;
+    video.preload = "metadata";
+    await waitForMetadata(video);
+
+    const canvas = document.createElement("canvas");
+    const context = canvas.getContext("2d");
+    if (!context) throw new Error("Unable to create video canvas.");
+
+    const scale = Math.min(1, options.videoMaxWidth / video.videoWidth);
+    const width = Math.max(2, Math.round((video.videoWidth * scale) / 2) * 2);
+    const height = Math.max(2, Math.round((video.videoHeight * scale) / 2) * 2);
+
+    canvas.width = width;
+    canvas.height = height;
+
+    if (!canvas.captureStream) {
+      reportProgress(onProgress, 1);
+      return file;
+    }
+
+    const canvasStream = canvas.captureStream(options.videoFps);
+    const sourceStream = getCaptureStream(video);
+    const audioTrack = sourceStream?.getAudioTracks?.()[0];
+    if (audioTrack) canvasStream.addTrack(audioTrack);
+
+    const mimeType = getSupportedMimeType(VIDEO_MIME_TYPES);
+    const mediaRecorder = new MediaRecorder(canvasStream, {
+      ...(mimeType ? { mimeType } : {}),
+      videoBitsPerSecond: options.videoBitsPerSecond,
+      audioBitsPerSecond: options.audioBitsPerSecond,
+    });
+
+    return await recordMedia({
+      mediaElement: video,
+      mediaRecorder,
+      onProgress,
+      fallbackType: file.type,
+      onFrame: () => context.drawImage(video, 0, 0, width, height),
+    });
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+};
+
+const recordMedia = ({
+  mediaElement,
+  mediaRecorder,
+  onProgress,
+  fallbackType,
+  onFrame,
+  onStart,
+  onCleanup,
+}) =>
+  new Promise((resolve, reject) => {
+    const chunks = [];
+    let animationFrameId = null;
+
+    const cleanup = () => {
+      if (animationFrameId) cancelAnimationFrame(animationFrameId);
+      mediaRecorder.stream.getTracks().forEach((track) => track.stop());
+      onCleanup?.();
+    };
+
+    mediaRecorder.ondataavailable = (event) => {
+      if (event.data?.size > 0) chunks.push(event.data);
+    };
+
+    mediaRecorder.onerror = (event) => {
+      cleanup();
+      reject(event.error ?? new Error("Media compression failed."));
+    };
+
+    mediaRecorder.onstop = () => {
+      cleanup();
+      reportProgress(onProgress, 1);
+      resolve(new Blob(chunks, { type: mediaRecorder.mimeType || fallbackType }));
+    };
+
+    mediaElement.onended = () => {
+      if (mediaRecorder.state !== "inactive") mediaRecorder.stop();
+    };
+
+    const drawFrame = () => {
+      if (mediaElement.paused || mediaElement.ended) return;
+      onFrame?.();
+      if (mediaElement.duration) {
+        reportProgress(onProgress, mediaElement.currentTime / mediaElement.duration);
+      }
+      animationFrameId = requestAnimationFrame(drawFrame);
+    };
+
+    mediaRecorder.start();
+    onStart?.();
+    mediaElement
+      .play()
+      .then(() => {
+        drawFrame();
+      })
+      .catch((error) => {
+        cleanup();
+        reject(error);
+      });
+  });
 
 /**
- * Superfast compression configuration
+ * Compress media with lightweight browser-native paths.
+ *
+ * Keeps the same public signature as the previous ffmpeg-based version:
+ * compressMedia(file, onProgress, customOptions)
  */
-export async function compressMedia(
-  file,
-  onProgress = null,
-  customOptions = {}
-) {
-  const ffmpeg = await getFFmpeg();
-  if (!ffmpeg) {
-    throw new Error("FFmpeg instance failed to load.");
-  }
-
-  let progressCallback = null;
-
-  if (onProgress) {
-    progressCallback = ({ progress }) => {
-      if (progress >= 0 && progress <= 1) {
-        onProgress(progress);
-      }
-    };
-    ffmpeg.on("progress", progressCallback);
-  }
-
-  const inputName = file.name;
-
-  // --- Optimized Default Options ---
+export async function compressMedia(file, onProgress = null, customOptions = {}) {
   const defaultOptions = {
-    // 1. Force max width 1280 (720p), height scales automatically. Avoids 4K video causing crashes or extreme slowness
-    videoScale: "scale=1280:-2",
-    // 2. Reduce frame rate to 24fps, reducing the number of frames to encode
-    videoFps: "24",
-    // 3. Use CRF instead of fixed bitrate. 28 is a balance point for lower quality/high compression/faster speed
-    crf: "28",
-    // 4. Critical: Use the ultrafast preset, which sacrifices compression ratio for maximum speed
-    preset: "ultrafast",
-    audioBitrate: "96k", // Audio bitrate can also be slightly lowered
-    outputFormat: file.type.startsWith("video") ? "mp4" : "mp3",
+    imageMaxSizeMB: 1,
+    imageMaxWidthOrHeight: 1280,
+    imageQuality: 0.72,
+    videoMaxWidth: 854,
+    videoFps: 15,
+    videoBitsPerSecond: 700000,
+    audioBitsPerSecond: 64000,
   };
 
   const options = { ...defaultOptions, ...customOptions };
-  const outputName = `output.${options.outputFormat}`;
+  reportProgress(onProgress, 0);
 
-  await ffmpeg.writeFile(inputName, await fetchFile(file));
-
-  let args = [];
+  if (file.type.startsWith("image")) {
+    return chooseSmallerMedia(file, await compressImage(file, onProgress, options));
+  }
 
   if (file.type.startsWith("video")) {
-    args = [
-      "-i",
-      inputName,
-      "-vf",
-      options.videoScale,
-      "-c:v",
-      "libx264",
-      // Use CRF to control quality/size
-      "-crf",
-      options.crf,
-      // Fastest preset
-      "-preset",
-      options.preset,
-      "-r",
-      options.videoFps,
-      "-c:a",
-      "aac",
-      "-b:a",
-      options.audioBitrate,
-      // faststart allows video to start playing before fully downloading on the web
-      "-movflags",
-      "+faststart",
-      "-y",
-      outputName,
-    ];
-  } else if (file.type.startsWith("audio")) {
-    // Audio options remain standard, usually very fast
-    args = [
-      "-i",
-      inputName,
-      "-b:a",
-      options.audioBitrate,
-      "-ar",
-      "44100",
-      "-c:a",
-      options.outputFormat === "mp3" ? "libmp3lame" : "aac",
-      "-y",
-      outputName,
-    ];
-  } else {
-    throw new Error("Unsupported file type");
+    return chooseSmallerMedia(file, await compressVideo(file, onProgress, options));
   }
 
-  console.log("FFmpeg Command:", args.join(" ")); // Debug log
-
-  await ffmpeg.exec(args);
-
-  const data = await ffmpeg.readFile(outputName);
-
-  // Cleanup memory
-  await ffmpeg.deleteFile(inputName);
-  await ffmpeg.deleteFile(outputName);
-
-  if (progressCallback) {
-    ffmpeg.off("progress", progressCallback);
+  if (file.type.startsWith("audio")) {
+    return chooseSmallerMedia(file, await compressAudio(file, onProgress, options));
   }
 
-  return new Blob([data.buffer], {
-    type: file.type.startsWith("video")
-      ? `video/${options.outputFormat}`
-      : `audio/${options.outputFormat}`,
-  });
+  throw new Error("Unsupported file type");
 }

--- a/components/media/AudioRecorder.jsx
+++ b/components/media/AudioRecorder.jsx
@@ -13,6 +13,7 @@ import { ref, uploadBytesResumable, getDownloadURL } from "@firebase/storage";
 import { onAuthStateChanged } from "firebase/auth";
 
 import { storage, auth } from "../../app/firebaseConfig";
+import useBeforeUnloadWarning from "./useBeforeUnloadWarning";
 
 /**
  * Audio Recording and Upload Component
@@ -51,6 +52,8 @@ const AudioRecorder = ({ onUploadSuccess, onRequireLogin }) => {
     });
     return () => unsubscribe();
   }, []);
+
+  useBeforeUnloadWarning(status === "recording" || status === "uploading");
 
   // --- 2. Utility Functions ---
   const formatTime = (seconds) => {

--- a/components/media/ImageUploader.jsx
+++ b/components/media/ImageUploader.jsx
@@ -6,6 +6,7 @@ import { onAuthStateChanged } from "firebase/auth";
 import imageCompression from "browser-image-compression";
 
 import { storage, auth } from "../../app/firebaseConfig";
+import useBeforeUnloadWarning from "./useBeforeUnloadWarning";
 
 const ImageUploader = ({ onUploadSuccess, onRequireLogin, trigger }) => {
   const [file, setFile] = useState(null);
@@ -22,6 +23,8 @@ const ImageUploader = ({ onUploadSuccess, onRequireLogin, trigger }) => {
     const unsubscribe = onAuthStateChanged(auth, setUser);
     return () => unsubscribe();
   }, []);
+
+  useBeforeUnloadWarning(status === "compressing" || status === "uploading");
 
   const handlePick = () => {
     if (!user) {

--- a/components/media/VideoUploader.jsx
+++ b/components/media/VideoUploader.jsx
@@ -3,6 +3,7 @@ import { Loader2, Play, Send, X, Film } from "lucide-react";
 import { ref, uploadBytesResumable, getDownloadURL } from "@firebase/storage";
 import { onAuthStateChanged } from "firebase/auth";
 import { storage, auth } from "../../app/firebaseConfig";
+import useBeforeUnloadWarning from "./useBeforeUnloadWarning";
 
 // Fix: Detect supported mimeType at runtime instead of hardcoding
 const getSupportedMimeType = () => {
@@ -35,6 +36,8 @@ const VideoUploader = ({ onUploadSuccess, onRequireLogin, trigger }) => {
     const unsubscribe = onAuthStateChanged(auth, setUser);
     return () => unsubscribe();
   }, []);
+
+  useBeforeUnloadWarning(status === "compressing" || status === "uploading");
 
   const handlePickVideo = () => {
     if (!user) {

--- a/components/media/useBeforeUnloadWarning.js
+++ b/components/media/useBeforeUnloadWarning.js
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+
+const DEFAULT_WARNING =
+  "Media processing is still in progress. Refreshing or closing this page will stop it.";
+
+export default function useBeforeUnloadWarning(
+  shouldWarn,
+  message = DEFAULT_WARNING,
+) {
+  useEffect(() => {
+    if (!shouldWarn) return;
+
+    const handleBeforeUnload = (event) => {
+      event.preventDefault();
+      event.returnValue = message;
+      return message;
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [message, shouldWarn]);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "name": "realpenpalapp",
       "version": "0.1.0",
       "dependencies": {
-        "@ffmpeg/ffmpeg": "^0.12.15",
-        "@ffmpeg/util": "^0.12.2",
         "@firebase/storage": "^0.12.3",
         "@sentry/nextjs": "^8.26.0",
         "browser-image-compression": "^2.0.2",
@@ -388,36 +386,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.1.1.tgz",
       "integrity": "sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw=="
-    },
-    "node_modules/@ffmpeg/ffmpeg": {
-      "version": "0.12.15",
-      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.12.15.tgz",
-      "integrity": "sha512-1C8Obr4GsN3xw+/1Ww6PFM84wSQAGsdoTuTWPOj2OizsRDLT4CXTaVjPhkw6ARyDus1B9X/L2LiXHqYYsGnRFw==",
-      "license": "MIT",
-      "dependencies": {
-        "@ffmpeg/types": "^0.12.4"
-      },
-      "engines": {
-        "node": ">=18.x"
-      }
-    },
-    "node_modules/@ffmpeg/types": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/@ffmpeg/types/-/types-0.12.4.tgz",
-      "integrity": "sha512-k9vJQNBGTxE5AhYDtOYR5rO5fKsspbg51gbcwtbkw2lCdoIILzklulcjJfIDwrtn7XhDeF2M+THwJ2FGrLeV6A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.x"
-      }
-    },
-    "node_modules/@ffmpeg/util": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@ffmpeg/util/-/util-0.12.2.tgz",
-      "integrity": "sha512-ouyoW+4JB7WxjeZ2y6KpRvB+dLp7Cp4ro8z0HIVpZVCM7AwFlHa0c4R8Y/a4M3wMqATpYKhC7lSFHQ0T11MEDw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.x"
-      }
     },
     "node_modules/@firebase/analytics": {
       "version": "0.10.12",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@ffmpeg/ffmpeg": "^0.12.15",
-    "@ffmpeg/util": "^0.12.2",
     "@firebase/storage": "^0.12.3",
     "@sentry/nextjs": "^8.26.0",
     "browser-image-compression": "^2.0.2",


### PR DESCRIPTION
## Summary
- replace ffmpeg.wasm compression with a browser-native compressMedia(file, onProgress, customOptions) helper
- support images through browser-image-compression and audio/video through MediaRecorder-based paths
- add adaptive lowEnd / balanced / capable compression profiles based on browser device hints
- remove @ffmpeg/ffmpeg and @ffmpeg/util dependencies
- add a local-only compression test panel on /media that does not upload to Firebase, including detected profile and profile override controls

## Testing
- npm run lint
- npm run build

## Notes
- Tested locally with image/audio files; examples included a ~5 MB image compressing to ~800 KB and a 4.18 MB MP3 compressing to 1.92 MB.
- Upload has not been tested yet.
- Video compression remains browser/device dependent, but this avoids shipping ffmpeg.wasm to low-end devices.