### PR TITLE
Add created_at field to child user creation

### DIFF
--- a/app/api/createChild/route.js
+++ b/app/api/createChild/route.js
@@ -43,6 +43,7 @@ export default async function handler(req, res) {
     
     // Save Firestore user document; roll back auth user on failure
     try {
+      sanitizedData.created_at = new Date();
       await db.collection("users").doc(uid).set(sanitizedData);
     } catch (firestoreError) {
       await auth.deleteUser(uid).catch(() => {}); // best-effort cleanup


### PR DESCRIPTION
Added created_at when creating child user documents in the createChild admin API to ensure newly created Firestore documents include a creation timestamp.