### PR TITLE
Refactor email sending into shared utility

### DIFF
--- a/app/api/report/route.js
+++ b/app/api/report/route.js
@@ -15,8 +15,9 @@
  */
 
 import { NextResponse } from "next/server";
-import nodemailer from "nodemailer";
+import { sendEmailMessage } from "../../utils/email";
 import { auth, db } from "../../firebaseAdmin";
+import { logError } from "../../utils/analytics";
 
 export const runtime = "nodejs";
 
@@ -146,40 +147,10 @@ Reported Excerpt:
       </html>
     `;
 
-    const requiredEnvVars = [
-      "PENPAL_EMAIL",
-      "PENPAL_EMAIL_PASSWORD",
-      "CPANEL_SMTP_HOST",
-      "CPANEL_SMTP_PORT",
-    ];
-
-    const missingEnvVars = requiredEnvVars.filter((key) => !process.env[key]);
-
-    if (missingEnvVars.length > 0) {
-      return jsonError(
-        `Missing email environment variables: ${missingEnvVars.join(", ")}`,
-        500
-      );
-    }
-
-    const smtpPort = Number(process.env.CPANEL_SMTP_PORT);
-
-    if (Number.isNaN(smtpPort)) {
-      return jsonError("CPANEL_SMTP_PORT must be a number.", 500);
-    }
-
-    const transporter = nodemailer.createTransport({
-      host: process.env.CPANEL_SMTP_HOST,
-      port: smtpPort,
-      secure: smtpPort === 465,
-      auth: {
-        user: process.env.PENPAL_EMAIL,
-        pass: process.env.PENPAL_EMAIL_PASSWORD,
-      },
-    });
+    // SMTP config validation is handled inside `sendEmailMessage`
 
     try {
-      await transporter.sendMail({
+      await sendEmailMessage({
         to: process.env.PENPAL_EMAIL,
         from: process.env.PENPAL_EMAIL,
         subject: "Message Reported",

--- a/app/utils/dormantConversationHelpers.js
+++ b/app/utils/dormantConversationHelpers.js
@@ -1,18 +1,9 @@
 import { db } from "../firebaseAdmin";
-import nodemailer from "nodemailer";
+import { sendEmailMessage } from "./email";
 import { logError } from "./analytics";
 import generateDormantConversationEmailTemplate from "../api/dormantConversation/emailTemplate";
 
 
-const transporter = nodemailer.createTransport({
-    host: process.env.CPANEL_SMTP_HOST,
-    port: parseInt(process.env.CPANEL_SMTP_PORT),
-    secure: process.env.CPANEL_SMTP_PORT == 465, // SSL for 465
-    auth: {
-        user: process.env.PENPAL_EMAIL, //sender email
-        pass: process.env.PENPAL_EMAIL_PASSWORD, //sender password (cPanel email password)
-    },
-});
 
 
 const formatListWithAnd = (arr) => {
@@ -72,8 +63,8 @@ export const sendEmail = async (conversationId, members, toEmails, reason) => {
     };
   }
   try {
-    // Send the email
-    await transporter.sendMail(msg);
+  // Send the email
+  await sendEmailMessage(msg);
 
     if (db) {
       const fieldToUpdate =

--- a/app/utils/email.js
+++ b/app/utils/email.js
@@ -1,0 +1,36 @@
+import nodemailer from "nodemailer";
+
+function validateEmailConfig() {
+  const requiredEnvVars = [
+    "PENPAL_EMAIL",
+    "PENPAL_EMAIL_PASSWORD",
+    "CPANEL_SMTP_HOST",
+    "CPANEL_SMTP_PORT",
+  ];
+
+  const missingEnvVars = requiredEnvVars.filter((key) => !process.env[key]);
+  if (missingEnvVars.length > 0) {
+    throw new Error(`Missing email environment variables: ${missingEnvVars.join(", ")}`);
+  }
+
+  const smtpPort = Number(process.env.CPANEL_SMTP_PORT);
+  if (Number.isNaN(smtpPort)) {
+    throw new Error("CPANEL_SMTP_PORT must be a number.");
+  }
+  return smtpPort;
+}
+
+export async function sendEmailMessage(mailOptions) {
+  const smtpPort = validateEmailConfig();
+  const transporter = nodemailer.createTransport({
+    host: process.env.CPANEL_SMTP_HOST,
+    port: smtpPort,
+    secure: smtpPort === 465,
+    auth: {
+      user: process.env.PENPAL_EMAIL,
+      pass: process.env.PENPAL_EMAIL_PASSWORD,
+    },
+  });
+
+  return transporter.sendMail(mailOptions);
+}


### PR DESCRIPTION
Summary

* Added a shared email utility to centralize SMTP configuration and email sending.
* Updated dormantConversationHelpers to use the shared utility.
* Updated the report route to use the shared utility.
* Removed duplicated Nodemailer configuration and SMTP validation logic.

Testing

* Ran npm run lint.
* Verified SMTP configuration now exists only in app/utils/email.js.
* No functional changes intended; refactor only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Refactor
- Reworked report notification email sending to use a centralized delivery helper with upfront SMTP configuration validation (host, port, credentials).  
- Improved failure handling by capturing and logging delivery errors while keeping the same error response behavior when sending fails.  
- Removed direct email transport setup from the report endpoint, improving consistency across submission scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->