### PR TITLE
Share public paths between contexts

### DIFF
--- a/app/contexts/InactivityContext.js
+++ b/app/contexts/InactivityContext.js
@@ -7,6 +7,7 @@ import {
   useState,
 } from "react";
 import { useRouter, usePathname } from "next/navigation";
+import { PUBLIC_PATHS } from "../utils/publicPaths";
 
 const InactivityContext = createContext();
 
@@ -14,16 +15,7 @@ export function InactivityProvider({ children }) {
   const router = useRouter();
   const pathname = usePathname();
 
-  const publicPaths = [
-    "/",
-    "/login",
-    "/create-acc",
-    "/reset-password",
-    "/choose-profile",
-    "/choose-account",
-  ];
-
-  const isPublicPath = publicPaths.includes(pathname);
+  const isPublicPath = PUBLIC_PATHS.includes(pathname);
 
   const [inactivityWarning, setInactivityWarning] = useState(false);
   const [inactivitySecondsLeft, setInactivitySecondsLeft] = useState(0);

--- a/app/utils/publicPaths.js
+++ b/app/utils/publicPaths.js
@@ -9,4 +9,6 @@ export const PUBLIC_PATHS = [
   "/contact",
   "/donate",
   "/welcome",
+  "/privacy-policy",
+  "/terms-conditions",
 ];

--- a/app/utils/publicPaths.js
+++ b/app/utils/publicPaths.js
@@ -1,0 +1,12 @@
+export const PUBLIC_PATHS = [
+  "/",
+  "/login",
+  "/create-acc",
+  "/reset-password",
+  "/choose-profile",
+  "/choose-account",
+  "/about",
+  "/contact",
+  "/donate",
+  "/welcome",
+];

--- a/contexts/UserContext.js
+++ b/contexts/UserContext.js
@@ -6,23 +6,9 @@ import { useRouter, usePathname } from 'next/navigation';
 import { auth, db } from '../app/firebaseConfig';
 import { getUserPfp } from '../app/utils/conversationsFunctions';
 import LoadingSpinner from '../components/loading/LoadingSpinner';
+import { PUBLIC_PATHS } from "../app/utils/publicPaths";
 
 const UserContext = createContext();
-
-const PUBLIC_PATHS = [
-  '/login',
-  '/choose-profile',
-  '/choose-account',
-  '/',
-  '/about',
-  '/contact',
-  '/donate',
-  '/welcome',
-  '/create-acc',
-  '/reset-password',
-    "/privacy-policy",
-    "/terms-conditions",
-];
 
 export function UserProvider({ children }) {
   const [user, setUser] = useState(null);


### PR DESCRIPTION
Summary
- Moved the shared public route list into a single file.
- Updated UserContext and InactivityContext to use the shared constant.
- Removed duplicate public route definitions.

Testing
- Ran locally with npm run dev.
- Verified the app compiles successfully.
- Verified public routes and protected route behavior still work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated the list of public routes into a shared location.
  * Updated route checks to use the shared list across the app.
  * This helps keep public-page handling consistent and easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->