### PR TITLE
Add Enter and Escape keyboard support for dialogs

### DIFF
--- a/app/conversation/[id]/page.js
+++ b/app/conversation/[id]/page.js
@@ -28,6 +28,7 @@ import ConfirmReportPopup from "../../../components/general/message/ConfirmRepor
 import { useRouter } from "next/navigation";
 import MessagesSkeleton from "../../../components/loading/MessagesSkeleton";
 import Image from "next/image";
+import Dialog from "../../../components/general/Dialog";
 import { PageContainer } from "../../../components/general/PageContainer";
 import { PageBackground } from "../../../components/general/PageBackground";
 import { AlertTriangle } from "lucide-react";
@@ -1187,32 +1188,33 @@ export default function Page({ params }) {
 
         {/* ===== POPUPS ===== */}
         {showCloseDialog && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-30 backdrop-blur-sm">
-            <div className="bg-gray-100 p-6 rounded-2xl shadow-lg w-[345px] mx-auto max-h-[80vh] overflow-auto">
-              <h2 className="text-xl font-semibold mb-1 text-black">
-                {editingMessageId ? "Discard changes?" : "Close this message?"}
-              </h2>
-              <p className="text-gray-600 mb-6 text-sm">
-                {editingMessageId
-                  ? "Your changes will not be saved."
-                  : "Your message will be saved as a draft."}
-              </p>
-              <div className="flex space-x-3">
-                <button
-                  onClick={handleContinueEditing}
-                  className="flex-1 bg-[#4E802A] text-white py-3 px-4 rounded-2xl"
-                >
-                  Stay on page
-                </button>
-                <button
-                  onClick={handleConfirmClose}
-                  className="flex-1 bg-gray-200 text-[#4E802A] py-3 px-4 rounded-2xl"
-                >
-                  {editingMessageId ? "Discard" : "Close"}
-                </button>
-              </div>
-            </div>
-          </div>
+          <Dialog
+            isOpen={showCloseDialog}
+            onClose={handleContinueEditing}
+            variant="closeDialog"
+            closeOnOverlay={false}
+            containerClassName="max-h-[80vh] overflow-auto"
+            title={editingMessageId ? "Discard changes?" : "Close this message?"}
+            subtitle={
+              editingMessageId
+                ? "Your changes will not be saved."
+                : "Your message will be saved as a draft."
+            }
+            buttons={[
+              {
+                text: "Stay on page",
+                onClick: handleContinueEditing,
+                variant: "primary",
+                className: "flex-1",
+              },
+              {
+                text: editingMessageId ? "Discard" : "Close",
+                onClick: handleConfirmClose,
+                variant: "secondary",
+                className: "flex-1",
+              },
+            ]}
+          />
         )}
 
         {showReportPopup && (

--- a/components/general/Dialog.jsx
+++ b/components/general/Dialog.jsx
@@ -56,6 +56,30 @@ export default function Dialog({
     };
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose?.();
+        return;
+      }
+
+      if (event.key === "Enter") {
+        const confirmButton = buttons.at(-1);
+
+        if (confirmButton?.onClick && !confirmButton.disabled) {
+          event.preventDefault();
+          confirmButton.onClick();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, buttons, onClose]);
+
   if (!isOpen) return null;
 
   // Render button with consistent styling


### PR DESCRIPTION
## Summary

Adds keyboard support to the reusable `Dialog` component.

### Changes
- Pressing Enter triggers the dialog's confirmation action.
- Pressing Escape dismisses the dialog.
- Keyboard listeners are only attached while the dialog is open and are properly cleaned up on close.

## Testing
- [x] Escape closes the dialog.
- [x] Enter triggers the confirmation action.
- [x] Existing mouse interactions continue to work.

## Note: Need to test on stable wifi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the close confirmation dialog with a shared, consistent dialog design.
  * Preserved context-specific messaging and actions when editing a message.
  * Improved dialog behavior for continuing to edit, discarding changes, or closing the conversation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->