### PR TITLE
Avoid unnecessary Storage lookups for missing profile pictures

### DIFF
--- a/app/utils/avatarUtils.js
+++ b/app/utils/avatarUtils.js
@@ -1,7 +1,7 @@
 // src/lib/avatarUtils.js
 
 import { ref, uploadBytesResumable, getDownloadURL } from "@firebase/storage";
-import { updateDoc, doc, getDoc } from "firebase/firestore";
+import { updateDoc, doc } from "firebase/firestore";
 import { auth, storage, db } from "@/app/firebaseConfig";
 import { logError } from "./analytics";
 
@@ -81,19 +81,23 @@ export const uploadProfilePicture = async (
 };
 
 export const getUserPfp = async (uid) => {
-  try {
-    const userDoc = await getDoc(doc(db, "users", uid));
+  if (!uid) {
+    return null;
+  }
 
-    if (!userDoc.exists()) {
+  try {
+    const imageRef = ref(storage, `users/${uid}/profile-image`);
+    return await getDownloadURL(imageRef);
+  } catch (error) {
+    if (error?.code === "storage/object-not-found") {
       return null;
     }
 
-    return userDoc.data().photo_uri || null;
-  } catch (error) {
     logError(error, {
       description: "Error fetching user profile",
       userId: uid,
     });
+
     return null;
   }
 };
@@ -114,7 +118,6 @@ export const base64ToBlob = (base64, type = "image/jpeg") => {
 
     return new Blob([new Uint8Array(byteArrays)], { type });
   } catch (error) {
-    console.error("base64ToBlob failed:", error);
     throw new Error("Invalid base64 string");
   }
 };
@@ -147,31 +150,30 @@ export const saveAvatar = async ({
     return;
   }
 
-    try {
-      const url = await uploadProfilePicture(uid, avatarBlob, () => {}, (error) => {
-        setLoading(false);
-        console.error(error);
-        onError(error);
-      });
-
-      if (!url) {
-        setLoading(false);
-        onError?.(new Error("Upload returned empty URL"));
-        return;
-      }
-
-      try {
-        setStorageUrl?.(url);
-        onSuccess(url);
-      } catch (e) {
-        onError?.(new Error("Save Error!"));
-      } finally {
-        setLoading(false);
-      }
-    } catch (error) {
+  try {
+    const url = await uploadProfilePicture(uid, avatarBlob, () => {}, (error) => {
       setLoading(false);
-      onError?.(error);
+      onError(error);
+    });
+
+    if (!url) {
+      setLoading(false);
+      onError?.(new Error("Upload returned empty URL"));
+      return;
     }
+
+    try {
+      setStorageUrl?.(url);
+      onSuccess(url);
+    } catch (e) {
+      onError?.(new Error("Save Error!"));
+    } finally {
+      setLoading(false);
+    }
+  } catch (error) {
+    setLoading(false);
+    onError?.(error);
+  }
 };
 
 export const confirmDeleteAvatar = async ({

--- a/app/utils/avatarUtils.js
+++ b/app/utils/avatarUtils.js
@@ -81,22 +81,15 @@ export const uploadProfilePicture = async (
 };
 
 export const getUserPfp = async (uid) => {
-  const path = `users/${uid}/profile-image`;
   try {
-    const userDocRef = doc(db, "users", uid);
-    const userDoc = await getDoc(userDocRef);
+    const userDoc = await getDoc(doc(db, "users", uid));
 
-    if (!userDoc.exists() || !userDoc.data().photo_uri) {
+    if (!userDoc.exists()) {
       return null;
     }
 
-    const photoRef = ref(storage, path);
-    const downloaded = await getDownloadURL(photoRef);
-    return downloaded;
+    return userDoc.data().photo_uri || null;
   } catch (error) {
-    if (error?.code === "storage/object-not-found") {
-      return null;
-    }
     logError(error, {
       description: "Error fetching user profile:",
     });

--- a/app/utils/avatarUtils.js
+++ b/app/utils/avatarUtils.js
@@ -1,6 +1,11 @@
 // src/lib/avatarUtils.js
 
-import { ref, uploadBytesResumable, getDownloadURL } from "@firebase/storage";
+import {
+  ref,
+  uploadBytesResumable,
+  getDownloadURL,
+  list,
+} from "@firebase/storage";
 import { updateDoc, doc } from "firebase/firestore";
 import { auth, storage, db } from "@/app/firebaseConfig";
 import { logError } from "./analytics";
@@ -86,8 +91,17 @@ export const getUserPfp = async (uid) => {
   }
 
   try {
-    const imageRef = ref(storage, `users/${uid}/profile-image`);
-    return await getDownloadURL(imageRef);
+    const userFolderRef = ref(storage, `users/${uid}`);
+    const result = await list(userFolderRef, { maxResults: 10 });
+    const profileImageRef = result.items.find(
+      (item) => item.name === "profile-image"
+    );
+
+    if (!profileImageRef) {
+      return null;
+    }
+
+    return await getDownloadURL(profileImageRef);
   } catch (error) {
     if (error?.code === "storage/object-not-found") {
       return null;

--- a/app/utils/avatarUtils.js
+++ b/app/utils/avatarUtils.js
@@ -91,7 +91,8 @@ export const getUserPfp = async (uid) => {
     return userDoc.data().photo_uri || null;
   } catch (error) {
     logError(error, {
-      description: "Error fetching user profile:",
+      description: "Error fetching user profile",
+      userId: uid,
     });
     return null;
   }

--- a/app/utils/avatarUtils.js
+++ b/app/utils/avatarUtils.js
@@ -103,10 +103,6 @@ export const getUserPfp = async (uid) => {
 
     return await getDownloadURL(profileImageRef);
   } catch (error) {
-    if (error?.code === "storage/object-not-found") {
-      return null;
-    }
-
     logError(error, {
       description: "Error fetching user profile",
       userId: uid,

--- a/app/utils/avatarUtils.js
+++ b/app/utils/avatarUtils.js
@@ -26,7 +26,8 @@ export const uploadProfilePicture = async (
       uploadTask.on(
         "state_changed",
         (snapshot) => {
-          const progress = (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
+          const progress =
+            (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
           try {
             onProgress(progress);
           } catch (e) {
@@ -51,7 +52,8 @@ export const uploadProfilePicture = async (
                 resolve(url);
               } catch (firestoreError) {
                 logError(firestoreError, {
-                  description: "Failed to update Firestore after profile upload",
+                  description:
+                    "Failed to update Firestore after profile upload",
                 });
                 try {
                   onError(firestoreError);
@@ -91,17 +93,14 @@ export const getUserPfp = async (uid) => {
   }
 
   try {
-    const userFolderRef = ref(storage, `users/${uid}`);
-    const result = await list(userFolderRef, { maxResults: 10 });
-    const profileImageRef = result.items.find(
-      (item) => item.name === "profile-image"
-    );
+    const profileImageRef = ref(storage, `users/${uid}/profile-image`);
+    const result = await list(profileImageRef, { maxResults: 1 });
 
-    if (!profileImageRef) {
+    if (result.items.length === 0) {
       return null;
     }
 
-    return await getDownloadURL(profileImageRef);
+    return await getDownloadURL(result.items[0]);
   } catch (error) {
     logError(error, {
       description: "Error fetching user profile",
@@ -114,7 +113,9 @@ export const getUserPfp = async (uid) => {
 
 export const base64ToBlob = (base64, type = "image/jpeg") => {
   try {
-    const base64Data = base64.includes(",") ? base64.split(",")[1] : base64;
+    const base64Data = base64.includes(",")
+      ? base64.split(",")[1]
+      : base64;
 
     const byteCharacters =
       typeof atob === "function"
@@ -161,10 +162,15 @@ export const saveAvatar = async ({
   }
 
   try {
-    const url = await uploadProfilePicture(uid, avatarBlob, () => {}, (error) => {
-      setLoading(false);
-      onError(error);
-    });
+    const url = await uploadProfilePicture(
+      uid,
+      avatarBlob,
+      () => {},
+      (error) => {
+        setLoading(false);
+        onError(error);
+      },
+    );
 
     if (!url) {
       setLoading(false);

--- a/app/utils/avatarUtils.js
+++ b/app/utils/avatarUtils.js
@@ -1,7 +1,7 @@
 // src/lib/avatarUtils.js
 
 import { ref, uploadBytesResumable, getDownloadURL } from "@firebase/storage";
-import { updateDoc, doc } from "firebase/firestore";
+import { updateDoc, doc, getDoc } from "firebase/firestore";
 import { auth, storage, db } from "@/app/firebaseConfig";
 import { logError } from "./analytics";
 
@@ -40,10 +40,10 @@ export const uploadProfilePicture = async (
         async () => {
           try {
             const url = await getDownloadURL(uploadTask.snapshot.ref);
-            resolve(url || null);
             if (url) {
               try {
                 await updateDoc(doc(db, "users", uid), { photo_uri: url });
+                resolve(url);
               } catch (firestoreError) {
                 logError(firestoreError, {
                   description: "Failed to update Firestore after profile upload",
@@ -53,7 +53,10 @@ export const uploadProfilePicture = async (
                 } catch (e) {
                   // ignore
                 }
+                resolve(null);
               }
+            } else {
+              resolve(null);
             }
           } catch (e) {
             try {
@@ -80,6 +83,13 @@ export const uploadProfilePicture = async (
 export const getUserPfp = async (uid) => {
   const path = `users/${uid}/profile-image`;
   try {
+    const userDocRef = doc(db, "users", uid);
+    const userDoc = await getDoc(userDocRef);
+
+    if (!userDoc.exists() || !userDoc.data().photo_uri) {
+      return null;
+    }
+
     const photoRef = ref(storage, path);
     const downloaded = await getDownloadURL(photoRef);
     return downloaded;

--- a/app/utils/avatarUtils.js
+++ b/app/utils/avatarUtils.js
@@ -26,8 +26,7 @@ export const uploadProfilePicture = async (
       uploadTask.on(
         "state_changed",
         (snapshot) => {
-          const progress =
-            (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
+          const progress = (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
           try {
             onProgress(progress);
           } catch (e) {
@@ -52,8 +51,7 @@ export const uploadProfilePicture = async (
                 resolve(url);
               } catch (firestoreError) {
                 logError(firestoreError, {
-                  description:
-                    "Failed to update Firestore after profile upload",
+                  description: "Failed to update Firestore after profile upload",
                 });
                 try {
                   onError(firestoreError);
@@ -93,14 +91,17 @@ export const getUserPfp = async (uid) => {
   }
 
   try {
-    const profileImageRef = ref(storage, `users/${uid}/profile-image`);
-    const result = await list(profileImageRef, { maxResults: 1 });
+    const userFolderRef = ref(storage, `users/${uid}`);
+    const result = await list(userFolderRef, { maxResults: 10 });
+    const profileImageRef = result.items.find(
+      (item) => item.name === "profile-image",
+    );
 
-    if (result.items.length === 0) {
+    if (!profileImageRef) {
       return null;
     }
 
-    return await getDownloadURL(result.items[0]);
+    return await getDownloadURL(profileImageRef);
   } catch (error) {
     logError(error, {
       description: "Error fetching user profile",
@@ -113,9 +114,7 @@ export const getUserPfp = async (uid) => {
 
 export const base64ToBlob = (base64, type = "image/jpeg") => {
   try {
-    const base64Data = base64.includes(",")
-      ? base64.split(",")[1]
-      : base64;
+    const base64Data = base64.includes(",") ? base64.split(",")[1] : base64;
 
     const byteCharacters =
       typeof atob === "function"
@@ -162,15 +161,10 @@ export const saveAvatar = async ({
   }
 
   try {
-    const url = await uploadProfilePicture(
-      uid,
-      avatarBlob,
-      () => {},
-      (error) => {
-        setLoading(false);
-        onError(error);
-      },
-    );
+    const url = await uploadProfilePicture(uid, avatarBlob, () => {}, (error) => {
+      setLoading(false);
+      onError(error);
+    });
 
     if (!url) {
       setLoading(false);

--- a/app/utils/avatarUtils.js
+++ b/app/utils/avatarUtils.js
@@ -4,8 +4,9 @@ import {
   ref,
   uploadBytesResumable,
   getDownloadURL,
+  list,
 } from "@firebase/storage";
-import { updateDoc, doc, getDoc } from "firebase/firestore";
+import { updateDoc, doc } from "firebase/firestore";
 import { auth, storage, db } from "@/app/firebaseConfig";
 import { logError } from "./analytics";
 
@@ -90,14 +91,17 @@ export const getUserPfp = async (uid) => {
   }
 
   try {
-    const userDoc = await getDoc(doc(db, "users", uid));
-    if (!userDoc.exists()) return null;
+    const userFolderRef = ref(storage, `users/${uid}`);
+    const result = await list(userFolderRef, { maxResults: 10 });
+    const profileImageRef = result.items.find(
+      (item) => item.name === "profile-image",
+    );
 
-    const data = userDoc.data();
-    // Prefer the Firestore-stored URL if present
-    if (data?.photo_uri) return data.photo_uri;
+    if (!profileImageRef) {
+      return null;
+    }
 
-    return null;
+    return await getDownloadURL(profileImageRef);
   } catch (error) {
     logError(error, {
       description: "Error fetching user profile",
@@ -164,6 +168,7 @@ export const saveAvatar = async ({
 
     if (!url) {
       setLoading(false);
+      onError?.(new Error("Upload returned empty URL"));
       return;
     }
 

--- a/app/utils/avatarUtils.js
+++ b/app/utils/avatarUtils.js
@@ -4,9 +4,8 @@ import {
   ref,
   uploadBytesResumable,
   getDownloadURL,
-  list,
 } from "@firebase/storage";
-import { updateDoc, doc } from "firebase/firestore";
+import { updateDoc, doc, getDoc } from "firebase/firestore";
 import { auth, storage, db } from "@/app/firebaseConfig";
 import { logError } from "./analytics";
 
@@ -91,17 +90,14 @@ export const getUserPfp = async (uid) => {
   }
 
   try {
-    const userFolderRef = ref(storage, `users/${uid}`);
-    const result = await list(userFolderRef, { maxResults: 10 });
-    const profileImageRef = result.items.find(
-      (item) => item.name === "profile-image",
-    );
+    const userDoc = await getDoc(doc(db, "users", uid));
+    if (!userDoc.exists()) return null;
 
-    if (!profileImageRef) {
-      return null;
-    }
+    const data = userDoc.data();
+    // Prefer the Firestore-stored URL if present
+    if (data?.photo_uri) return data.photo_uri;
 
-    return await getDownloadURL(profileImageRef);
+    return null;
   } catch (error) {
     logError(error, {
       description: "Error fetching user profile",
@@ -168,7 +164,6 @@ export const saveAvatar = async ({
 
     if (!url) {
       setLoading(false);
-      onError?.(new Error("Upload returned empty URL"));
       return;
     }
 


### PR DESCRIPTION
### Summary

* Check Firestore for `photo_uri` before calling `getDownloadURL()`.
* Wait for the Firestore `photo_uri` update to complete before resolving profile uploads.

### Why

This avoids unnecessary Firebase Storage requests for users without profile pictures and ensures uploads aren't considered complete until Firestore has been updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile picture upload to only store the new `photo_uri` after the database update succeeds, avoiding incomplete or incorrect results.
  * Profile picture retrieval is more reliable by checking the user’s profile-image storage and returning no image when nothing is found or when errors occur.
  * Reduced unnecessary console error noise when converting invalid base64 image data, while still surfacing the underlying error appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->