### PR TITLE
Add initial session storage caching

### DIFF
--- a/app/create-acc/page.js
+++ b/app/create-acc/page.js
@@ -14,6 +14,7 @@ import { auth, db } from "../firebaseConfig";
 import Link from "next/link";
 import Image from "next/image";
 import { updatePassword, signOut } from "firebase/auth";
+import { clearCachedUser } from "@/app/utils/sessionUserCache";
 import PasswordChecklist from "react-password-checklist";
 import Input from "../../components/general/Input";
 import Button from "../../components/general/Button";
@@ -116,6 +117,7 @@ export default function CreateAccount() {
           setDialogMessage(
             "Account creation timed out. Please try logging in again.",
           );
+          clearCachedUser(user?.uid);
           await signOut(auth);
           router.push("/login");
           return;
@@ -384,6 +386,7 @@ export default function CreateAccount() {
                   btnText="Log Out"
                   color="grayBlue"
                   onClick={async () => {
+                    clearCachedUser(user?.uid);
                     await signOut(auth);
                     router.push("/");
                   }}

--- a/app/utils/sessionUserCache.js
+++ b/app/utils/sessionUserCache.js
@@ -64,7 +64,11 @@ export const getCachedUser = (uid) => {
     // Guard against malformed JSON or a sandboxed environment
     // where sessionStorage throws. Remove the bad entry so we
     // don't keep hitting this path on every read.
-    sessionStorage.removeItem(storageKey(uid));
+    try {
+      sessionStorage.removeItem(storageKey(uid));
+    } catch {
+      // Ignore storage cleanup failures.
+    }
     return null;
   }
 };

--- a/app/utils/sessionUserCache.js
+++ b/app/utils/sessionUserCache.js
@@ -1,0 +1,86 @@
+/**
+ * sessionUserCache.js
+ *
+ * Lightweight helpers for reading/writing the current user object
+ * to sessionStorage so we can potentially avoid unnecessary
+ * Firestore getDoc() calls during the same browser session.
+ *
+ * Integration plan:
+ *   - Before calling getDoc() in UserContext, check getCachedUser(uid).
+ *   - After fetching the user from Firestore, call setCachedUser(uid, user).
+ *
+ * TTL:
+ *   Cached entries expire after CACHE_TTL_MS (default 5 min).
+ *   getCachedUser() returns null for stale entries so the caller
+ *   falls through to a fresh Firestore read automatically.
+ *
+ * Open questions / TODO:
+ *   - Profile updates: when the user edits their profile, we need to
+ *     either invalidate the cache or update it in place.
+ *   - Multi-tab: sessionStorage is per-tab, so each tab will still
+ *     hit Firestore once. That's probably fine for now.
+ */
+
+/** Build a per-user storage key so different accounts never collide. */
+const storageKey = (uid) => `cached-user-${uid}`;
+
+/** How long a cached entry is considered fresh (5 minutes). */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Read the cached user object from sessionStorage.
+ * Returns the parsed user object, or null if nothing is cached
+ * or the entry has expired past CACHE_TTL_MS.
+ * @param {string} uid – the Firebase auth uid for the current user.
+ */
+export const getCachedUser = (uid) => {
+  try {
+    if (!uid) return null;
+    const raw = sessionStorage.getItem(storageKey(uid));
+    if (!raw) return null;
+
+    const { user, cachedAt } = JSON.parse(raw);
+
+    // If the entry is older than the TTL, treat it as a cache miss.
+    if (Date.now() - cachedAt > CACHE_TTL_MS) {
+      sessionStorage.removeItem(storageKey(uid));
+      return null;
+    }
+
+    return user ?? null;
+  } catch {
+    // Guard against malformed JSON or a sandboxed environment
+    // where sessionStorage throws.
+    return null;
+  }
+};
+
+/**
+ * Write the user object to sessionStorage wrapped in a
+ * timestamped envelope so getCachedUser() can enforce TTL.
+ * @param {string} uid – the Firebase auth uid for the current user.
+ * @param {Object} user – the user document data to cache.
+ */
+export const setCachedUser = (uid, user) => {
+  try {
+    if (!uid) return;
+    const envelope = JSON.stringify({ user, cachedAt: Date.now() });
+    sessionStorage.setItem(storageKey(uid), envelope);
+  } catch {
+    // sessionStorage may be full or unavailable; fail silently.
+  }
+};
+
+/**
+ * Remove the cached user from sessionStorage.
+ * Call this on logout to prevent stale data.
+ * @param {string} uid – the Firebase auth uid for the user to clear.
+ */
+export const clearCachedUser = (uid) => {
+  try {
+    if (!uid) return;
+    sessionStorage.removeItem(storageKey(uid));
+  } catch {
+    // Fail silently.
+  }
+};

--- a/app/utils/sessionUserCache.js
+++ b/app/utils/sessionUserCache.js
@@ -41,16 +41,30 @@ export const getCachedUser = (uid) => {
 
     const { user, cachedAt } = JSON.parse(raw);
 
+    // Reject malformed cache entries. If cachedAt is not a valid number,
+    // the TTL check below would evaluate against NaN and the entry would
+    // never expire.
+    if (
+      !Number.isFinite(cachedAt) ||
+      !user ||
+      typeof user !== "object"
+    ) {
+      sessionStorage.removeItem(storageKey(uid));
+      return null;
+    }
+
     // If the entry is older than the TTL, treat it as a cache miss.
     if (Date.now() - cachedAt > CACHE_TTL_MS) {
       sessionStorage.removeItem(storageKey(uid));
       return null;
     }
 
-    return user ?? null;
+    return user;
   } catch {
     // Guard against malformed JSON or a sandboxed environment
-    // where sessionStorage throws.
+    // where sessionStorage throws. Remove the bad entry so we
+    // don't keep hitting this path on every read.
+    sessionStorage.removeItem(storageKey(uid));
     return null;
   }
 };

--- a/components/bottom-nav-bar/index.js
+++ b/components/bottom-nav-bar/index.js
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { signOut } from "firebase/auth";
+import { clearCachedUser } from "@/app/utils/sessionUserCache";
 import {
   FaUserAlt,
   FaCompass,
@@ -80,6 +81,7 @@ export default function NavBar() {
     setIsNavigating(true);
 
     try {
+      clearCachedUser(auth.currentUser?.uid);
       await signOut(auth);
       router.push("/choose-profile");
     } catch (err) {

--- a/contexts/UserContext.js
+++ b/contexts/UserContext.js
@@ -27,8 +27,15 @@ export function UserProvider({ children }) {
   const pathname = usePathname();
 
   useEffect(() => {
+    let lastUid = null;
+
     const unsubscribe = onAuthStateChanged(auth, async (authUser) => {
       if (authUser) {
+        if (lastUid && lastUid !== authUser.uid) {
+          clearCachedUser(lastUid);
+        }
+
+        lastUid = authUser.uid;
         setUser(authUser);
 
         const userDocRef = doc(db, 'users', authUser.uid);  // Create the ref
@@ -37,6 +44,7 @@ export function UserProvider({ children }) {
         // Check sessionStorage cache before hitting Firestore
         const cachedUser = getCachedUser(authUser.uid);
         if (cachedUser) {
+          console.log('✅ Cache hit for user:', authUser.uid);
           setUserData(cachedUser);
           setUserType(cachedUser.user_type || 'Unknown Type');
           setDisplayName(cachedUser.first_name || '');
@@ -54,6 +62,7 @@ export function UserProvider({ children }) {
         }
         
         // Fetch user type from Firestore
+        console.log('⬇️ Fetching user from Firestore for user:', authUser.uid);
         try {
           const userDoc = await getDoc(userDocRef);
           
@@ -89,7 +98,10 @@ export function UserProvider({ children }) {
           setLoading(false);
         }
       } else {
-        clearCachedUser(authUser?.uid);
+        if (lastUid) {
+          clearCachedUser(lastUid);
+        }
+        lastUid = null;
         setUser(null);
         setUserType(null);
         setUserData(null);

--- a/contexts/UserContext.js
+++ b/contexts/UserContext.js
@@ -7,6 +7,11 @@ import { auth, db } from '../app/firebaseConfig';
 import { getUserPfp } from '../app/utils/avatarUtils';
 import LoadingSpinner from '../components/loading/LoadingSpinner';
 import { PUBLIC_PATHS } from "../app/utils/publicPaths";
+import {
+  getCachedUser,
+  setCachedUser,
+  clearCachedUser,
+} from "@/app/utils/sessionUserCache";
 
 const UserContext = createContext();
 
@@ -28,6 +33,25 @@ export function UserProvider({ children }) {
 
         const userDocRef = doc(db, 'users', authUser.uid);  // Create the ref
         setUserDocRef(userDocRef);  // Set it in state
+
+        // Check sessionStorage cache before hitting Firestore
+        const cachedUser = getCachedUser(authUser.uid);
+        if (cachedUser) {
+          setUserData(cachedUser);
+          setUserType(cachedUser.user_type || 'Unknown Type');
+          setDisplayName(cachedUser.first_name || '');
+
+          try {
+            const pfp = await getUserPfp(authUser.uid);
+            setProfileImage(pfp || '');
+          } catch (error) {
+            console.error('Error fetching profile image:', error);
+            setProfileImage('');
+          }
+
+          setLoading(false);
+          return;
+        }
         
         // Fetch user type from Firestore
         try {
@@ -35,6 +59,7 @@ export function UserProvider({ children }) {
           
           if (userDoc.exists()) {
             const fetchedUserData = userDoc.data();
+            setCachedUser(authUser.uid, fetchedUserData);
             setUserData(fetchedUserData);
             setUserType(fetchedUserData.user_type || 'Unknown Type');
             setDisplayName(fetchedUserData.first_name || '');
@@ -64,6 +89,7 @@ export function UserProvider({ children }) {
           setLoading(false);
         }
       } else {
+        clearCachedUser(authUser?.uid);
         setUser(null);
         setUserType(null);
         setUserData(null);


### PR DESCRIPTION
I put together a first pass of the session-storage approach. I did lean on AI for parts of the implementation since I'm still learning this area, but I wanted to get something working so we'd have something concrete to discuss. I'd definitely appreciate any feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved sign-in session loading by using recently cached profile information when available.
  * Reduced unnecessary profile data requests and refreshed cached profile details, including profile images.

* **Bug Fixes**
  * Cleared cached account information during logout, account-creation timeout, account switching, and unauthenticated sessions.
  * Expired, invalid, or unavailable cached data is now handled automatically to help prevent stale account information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->